### PR TITLE
Case now checks :string instead of defaulting

### DIFF
--- a/src/babashka/process.clj
+++ b/src/babashka/process.clj
@@ -195,8 +195,8 @@
 
 (defn- copy [in out encoding]
   (let [[out post-fn] (if (keyword? out)
-                        (case :string
-                          [(java.io.StringWriter.) str])
+                        (case out
+                          :string [(java.io.StringWriter.) str])
                         [out identity])]
     (io/copy in out :encoding encoding)
     (post-fn out)))


### PR DESCRIPTION
Following the discussion on slack.

The only keyword values allowed are `:string` and `:inherit`.
`:inherit` is explicitly not allowed when calling `copy` so it seems safe to constrain it

https://github.com/babashka/process/blob/4c6699d06b49773d3e5c5b4c11d3334fb78cc996/src/babashka/process.clj#L229-L234 


