### PR TITLE
Add BlockingDeref to process

### DIFF
--- a/src/babashka/process.clj
+++ b/src/babashka/process.clj
@@ -111,7 +111,12 @@
       (assoc this
              :exit exit-code
              :out out
-             :err err))))
+             :err err)))
+  clojure.lang.IBlockingDeref
+  (deref [this timeout-ms timeout-value]
+    (if (.waitFor proc timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)
+      @this
+      timeout-value)))
 
 (defmethod print-method Process [proc ^java.io.Writer w]
   (.write w (pr-str (into {} proc))))

--- a/test/babashka/process_test.clj
+++ b/test/babashka/process_test.clj
@@ -152,7 +152,10 @@
                      check
                      :out)))
     (is (string? (-> (sh "ls -la")
-                     :out)))))
+                     :out))))
+  (testing "deref timeout"
+    (is (= ::timeout (deref (process ["clojure" "-e" "(Thread/sleep 500)"]) 250 ::timeout)))
+    (is (= 0 (:exit (deref (process ["ls"]) 250 nil))))))
 
 (defmacro ^:private jdk9+ []
   (if (identical? ::ex


### PR DESCRIPTION
This allows doing `(deref)` with a timeout.  Fix #50 