### PR TITLE
Add cljdoc config

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,4 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Changelog" {:file "CHANGELOG.md"}]]
+ :cljdoc/languages ["clj"]}


### PR DESCRIPTION
Because it has cljc files, cljdoc assumes that babashka/process is a Clojure
and ClojureScript project. Explicitly telling cljdoc that this is a
Clojure only project will allow docs to build successfully on cljdoc.

Closes #56