### PR TITLE
define pprint/simple-dispatch for Process records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Issue [#53](https://github.com/babashka/process/issues/53):
-  - Using `pprint` on a `Process` now prints the process as a map instead of `pprint` not having a preference between `IPersistentMap` and `IDeref`.
+  - Added namespace `babashka.process.pprint` which defines how to `pprint` a `Process` record (if loaded).
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Issue [#53](https://github.com/babashka/process/issues/53):
+  - Using `pprint` on a `Process` now prints the process as a map instead of `pprint` not having a preference between `IPersistentMap` and `IDeref`.
+
 ## 0.1.1
 
 Similar to `tools.build.api/process`, `process` now supports appending output to

--- a/README.md
+++ b/README.md
@@ -437,25 +437,6 @@ Because `process` spawns threads for non-blocking I/O, you might have to run
 `(shutdown-agents)` at the end of your Clojure JVM scripts to force
 termination. Babashka does this automatically.
 
-### Clojure.pprint
-
-When pretty-printing a process, you will get an exception:
-
-``` clojure
-(require '[clojure.pprint :as pprint])
-(pprint/pprint (process ["ls"]))
-Execution error (IllegalArgumentException) at user/eval257 (REPL:1).
-Multiple methods in multimethod 'simple-dispatch' match dispatch value: class babashka.process.Process -> interface clojure.lang.IDeref and interface clojure.lang.IPersistentMap, and neither is preferred
-```
-
-The reason is that a process is both a record and a `clojure.lang.IDeref` and
-pprint does not have a preference for how to print this. This can be resolved
-using:
-
-``` clojure
-(prefer-method pprint/simple-dispatch clojure.lang.IPersistentMap clojure.lang.IDeref)
-```
-
 ## License
 
 Copyright © 2020-2021 Michiel Borkent

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -1,6 +1,7 @@
 (ns babashka.process
   (:require [babashka.fs :as fs]
             [clojure.java.io :as io]
+            [clojure.pprint :as pprint :only [pprint simple-dispatch]]
             [clojure.string :as str])
   (:import [java.lang ProcessBuilder$Redirect]))
 
@@ -122,6 +123,9 @@
 
 (defmethod print-method Process [proc ^java.io.Writer w]
   (.write w (pr-str (into {} proc))))
+
+(defmethod pprint/simple-dispatch Process [proc]
+  (pprint/pprint (into {} proc)))
 
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- proc->Process [^java.lang.Process proc cmd prev]

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -1,7 +1,6 @@
 (ns babashka.process
   (:require [babashka.fs :as fs]
             [clojure.java.io :as io]
-            [clojure.pprint :as pprint :only [pprint simple-dispatch]]
             [clojure.string :as str])
   (:import [java.lang ProcessBuilder$Redirect]))
 
@@ -123,9 +122,6 @@
 
 (defmethod print-method Process [proc ^java.io.Writer w]
   (.write w (pr-str (into {} proc))))
-
-(defmethod pprint/simple-dispatch Process [proc]
-  (pprint/pprint (into {} proc)))
 
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- proc->Process [^java.lang.Process proc cmd prev]

--- a/src/babashka/process/pprint.clj
+++ b/src/babashka/process/pprint.clj
@@ -1,0 +1,5 @@
+(ns babashka.process.pprint
+  (:require [clojure.pprint :as pprint :only [pprint simple-dispatch]]))
+
+(defmethod pprint/simple-dispatch babashka.process.Process [proc]
+  (pprint/pprint (into {} proc)))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -2,6 +2,7 @@
   (:require [babashka.fs :as fs]
             [babashka.process :refer [tokenize process check sh $ pb start] :as p]
             [clojure.java.io :as io]
+            [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.test :as t :refer [deftest is testing]]))
 
@@ -194,7 +195,7 @@
 
 (deftest pprint-test
   (testing "pprint prints process as a map (not ambiguous on pprint/simple-dispatch multimethod)"
-    (is (str/includes? (with-out-str (-> (process "cat missing-file.txt") clojure.pprint/pprint)) ":proc"))))
+    (is (str/includes? (with-out-str (-> (process "cat missing-file.txt") pprint)) ":proc"))))
 
 (defmacro ^:private jdk9+ []
   (if (identical? ::ex
@@ -266,4 +267,4 @@
 
 (when-windows
   (deftest ^:windows windows-pprint-test
-    (is (str/includes? (with-out-str (-> (process "cmd /c type missing-file.txt") clojure.pprint/pprint)) ":proc"))))
+    (is (str/includes? (with-out-str (-> (process "cmd /c type missing-file.txt") pprint)) ":proc"))))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -192,6 +192,10 @@
                    :err-file out})
       (is (= 2 (count (re-seq #"error" (slurp out))))))))
 
+(deftest pprint-test
+  (testing "pprint prints process as a map (not ambiguous on pprint/simple-dispatch multimethod)"
+    (is (str/includes? (with-out-str (-> (process "cat missing-file.txt") clojure.pprint/pprint)) ":proc"))))
+
 (defmacro ^:private jdk9+ []
   (if (identical? ::ex
                   (try (import 'java.lang.ProcessHandle)
@@ -259,3 +263,7 @@
       (let [proc @(p/process ["git " "status"] {:out :string})]
         (is (string? (:out proc)))
         (is (zero? (:exit proc))))))
+
+(when-windows
+  (deftest ^:windows windows-pprint-test
+    (is (str/includes? (with-out-str (-> (process "cmd /c type missing-file.txt") clojure.pprint/pprint)) ":proc"))))


### PR DESCRIPTION
closes #53 

- add `pprint/simple-dispatch` definition for `Process` records
- add tests that verify no exception is thrown when `pprint`ing a `Process`
- remove README section that describes the exception condition

I tried to do some of the housekeeping to maybe make life a little easier, but obviously feel free to tweak those or just throw them out. 
I added tests for Windows and non-Windows primarily for my convenience since I'm working primarily in Windows - then, I figured it's unlikely to hurt anything to have both tests, so I left them both there.