### PR TITLE
add cmd-print-fn option to process fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Issue [#53](https://github.com/babashka/process/issues/53):
   - Added namespace `babashka.process.pprint` which defines how to `pprint` a `Process` record (if loaded).
 - Part of feature request [#1249](https://github.com/babashka/babashka/issues/1249):
-  - Added `:cmd-print-fn` option to `process` options to side-effect command tokens
+  - Added `:pre-start-fn` option to `process` options to side-effect command tokens
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Issue [#53](https://github.com/babashka/process/issues/53):
   - Added namespace `babashka.process.pprint` which defines how to `pprint` a `Process` record (if loaded).
+- Part of feature request [#1249](https://github.com/babashka/babashka/issues/1249):
+  - Added `:cmd-print-fn` option to `process` options to side-effect command tokens
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ need it.
     - `:escape`: function that will applied to each stringified argument. On
       Windows this defaults to prepending a backslash before a double quote. On
       other operating systems it defaults to `identity`.
+    - `:cmd-print-fn`: a one-argument function that gets called with a vector of
+      the tokenized command just before the process is started. Can be useful for 
+      debugging or reporting. Any return value from the function is discarded.
     - `:shutdown`: shutdown hook, defaults to `nil`. Takes process
       map. Typically used with `destroy` or `destroy-tree` to ensure long
       running processes are cleaned up on shutdown.
@@ -277,6 +280,25 @@ Here is an example where we read the output of `yes` line by line and print it o
       (let [line (read-line)]
         (println :line line))
       (recur))))
+```
+
+## Printing command
+
+We can use `:cmd-print-fn` to report commands being run:
+
+``` clojure
+(require '[babashka.process :refer [process]])
+
+(doseq [file ["LICENSE" "CHANGELOG.md"]]
+         (-> (process (str "head -1 " file) {:out :string 
+                                             :cmd-print-fn #(apply println "Running" %)})
+             deref :out println))
+
+Running head -1 LICENSE
+Eclipse Public License - v 1.0
+
+Running head -1 CHANGELOG.md
+# Changelog
 ```
 
 ## sh

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ need it.
     - `:escape`: function that will applied to each stringified argument. On
       Windows this defaults to prepending a backslash before a double quote. On
       other operating systems it defaults to `identity`.
-    - `:cmd-print-fn`: a one-argument function that gets called with a vector of
-      the tokenized command just before the process is started. Can be useful for 
-      debugging or reporting. Any return value from the function is discarded.
+    - `:pre-start-fn`: a one-argument function that, if present, gets called with a 
+      map of process info just before the process is started. Can be useful for debugging 
+      or reporting. Any return value from the function is discarded.
+      
+      Map contents:
+      - `:cmd` - a vector of the tokens of the command to be executed (e.g. `["ls" "foo"]`)
     - `:shutdown`: shutdown hook, defaults to `nil`. Takes process
       map. Typically used with `destroy` or `destroy-tree` to ensure long
       running processes are cleaned up on shutdown.
@@ -284,14 +287,14 @@ Here is an example where we read the output of `yes` line by line and print it o
 
 ## Printing command
 
-We can use `:cmd-print-fn` to report commands being run:
+We can use `:pre-start-fn` to report commands being run:
 
 ``` clojure
 (require '[babashka.process :refer [process]])
 
 (doseq [file ["LICENSE" "CHANGELOG.md"]]
-         (-> (process (str "head -1 " file) {:out :string 
-                                             :cmd-print-fn #(apply println "Running" %)})
+         (-> (process ["head" "-1" file] {:out :string 
+                                           :pre-start-fn #(apply println "Running" (:cmd %))})
              deref :out println))
 
 Running head -1 LICENSE

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -274,8 +274,9 @@
            cmd
            (build cmd opts))
          cmd (vec (.command pb))
-         interceptor-map {:cmd cmd}
-         _ (when pre-start-fn (pre-start-fn interceptor-map))
+         _ (when pre-start-fn
+             (let [interceptor-map {:cmd cmd}]
+               (pre-start-fn interceptor-map)))
          proc (.start pb)
          stdin  (.getOutputStream proc)
          stdout (.getInputStream proc)

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -263,7 +263,7 @@
                  :out :out-enc
                  :err :err-enc
                  :shutdown
-                 :cmd-print-fn]} opts
+                 :pre-start-fn]} opts
          in (or in (:out prev))
          cmd (if (and (string? cmd)
                       (not (.exists (io/file cmd))))
@@ -274,7 +274,8 @@
            cmd
            (build cmd opts))
          cmd (vec (.command pb))
-         _ (when cmd-print-fn (cmd-print-fn cmd))
+         interceptor-map {:cmd cmd}
+         _ (when pre-start-fn (pre-start-fn interceptor-map))
          proc (.start pb)
          stdin  (.getOutputStream proc)
          stdout (.getInputStream proc)

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -262,7 +262,8 @@
          {:keys [:in :in-enc
                  :out :out-enc
                  :err :err-enc
-                 :shutdown]} opts
+                 :shutdown
+                 :cmd-print-fn]} opts
          in (or in (:out prev))
          cmd (if (and (string? cmd)
                       (not (.exists (io/file cmd))))
@@ -273,6 +274,7 @@
            cmd
            (build cmd opts))
          cmd (vec (.command pb))
+         _ (when cmd-print-fn (cmd-print-fn cmd))
          proc (.start pb)
          stdin  (.getOutputStream proc)
          stdout (.getInputStream proc)

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -204,12 +204,12 @@
       (require '[babashka.process] :reload '[babashka.process.pprint] :reload)
       (is (str/includes? (with-out-str (-> (process "cat missing-file.txt") pprint)) ":proc")))))
 
-(deftest cmd-print-test
+(deftest pre-start-fn-test
   (testing "a print fn option gets executed just before process is started"
-    (let [p #(apply println "Running" %)]
-      (is (str/includes? (with-out-str (process "ls" {:cmd-print-fn p}))
+    (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}]
+      (is (str/includes? (with-out-str (process "ls" p))
             "Running ls"))
-      (is (str/includes? (with-out-str (sh "cat foo" {:cmd-print-fn p}))
+      (is (str/includes? (with-out-str (sh "cat foo" p))
             "Running cat foo")))))
 
 (defmacro ^:private jdk9+ []
@@ -291,10 +291,10 @@
         (is (str/includes? (with-out-str (-> (process "cmd /c type missing-file.txt") pprint)) ":proc"))))))
 
 (when-windows
-  (deftest ^:windows windows-cmd-print-test
+  (deftest ^:windows windows-pre-start-fn-test
     (testing "a print fn option gets executed just before process is started"
-      (let [p #(apply println "Running" %)]
+      (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}]
         (is (re-find #"Running .*cmd\.exe .* file\.txt"
-              (with-out-str (process "cmd /c type file.txt" {:cmd-print-fn p}))))
+              (with-out-str (process "cmd /c type file.txt" p))))
         (is (re-find #"Running .*cmd\.exe .* file\.txt"
-              (with-out-str (-> (pb ["cmd" "/c" "type" "file.txt"] {:cmd-print-fn p}) start))))))))
+              (with-out-str (-> (pb ["cmd" "/c" "type" "file.txt"] p) start))))))))


### PR DESCRIPTION
Pursuant to https://github.com/babashka/babashka/issues/1249, this change adds an option to side-effect the tokenized command vector.

I'm sort of torn on whether to join the strings together to call the fn on the command line string instead of the vector of tokens. I sort of think that would be the more common usage, but if someone wants the tokens, they'd need to re-split the string that we'd join together. 

The windows test assertions are a little uglier to account for potentially varying paths to `cmd`.