### PR TITLE
quickstart dep version out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library is included in
 library:
 
 ``` clojure
-$ clojure -Sdeps '{:deps {babashka/process {:mvn/version "0.1.2"}}}'
+$ clojure -Sdeps '{:deps {babashka/process {:mvn/version "0.1.7"}}}'
 
 user=> (require '[clojure.string :as str])
 nil


### PR DESCRIPTION
Current quickstart includes old version that throws 

```
user=> (require '[babashka.process :refer [process check]])
Syntax error (IllegalArgumentException) compiling . at (babashka/process.cljc:523:10).
No matching method exec found taking 3 args for class org.graalvm.nativeimage.ProcessProperties
```