### PR TITLE
slurp `:err` in `check` only if it is an input stream

### DIFF
--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -101,9 +101,15 @@
         exit-code (:exit proc)
         err (:err proc)]
     (if (not (zero? exit-code))
-      (let [err (if (string? err)
+      (let [err (cond
+                  (string? err)
                   err
-                  (slurp (:err proc)))]
+
+                  (instance? java.io.InputStream err)
+                  (slurp err)
+
+                  :else
+                  nil)]
         (throw (ex-info (if (string? err)
                           err
                           "failed")

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -125,6 +125,11 @@
          (-> (process ["clojure" "-e" (str '(System/exit 1))])
              (check)))
         "With no :err string")
+    (is (thrown?
+         clojure.lang.ExceptionInfo #"failed"
+         (-> (process ["clojure" "-e" (str '(System/exit 1))] {:err *err*})
+             (check)))
+        "With :err set to *err*")
     (testing "and the exception"
       (let [command ["clojure" "-e" (str '(System/exit 1))]]
         (try


### PR DESCRIPTION
Hi,

could you please consider fix for `check` failure when the `:err` stream passed to process is a standard clj strem such as `*err*`. It addresses #90.

Thanks

