### PR TITLE
Add alive? function to expose java.lang.Process::isAlive

### DIFF
--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -593,5 +593,7 @@
         cmd (into cmd args)]
     (check (process prev cmd (merge default-shell-opts opts)))))
 
-(defn alive? [p]
+(defn alive?
+  "Returns `true` if the process is still running and false otherwise."
+  [p]
   (.isAlive ^java.lang.Process (:proc p)))

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -593,16 +593,5 @@
         cmd (into cmd args)]
     (check (process prev cmd (merge default-shell-opts opts)))))
 
-(def ^:private has-isAlive?
-  (boolean (try
-             (.getDeclaredMethod (java.lang.Class/forName "java.lang.Process")
-                                 "isAlive" (into-array java.lang.Class []))
-             (catch Throwable _ false))))
-
-(defmacro ^:private if-has-isAlive [then else]
-  (if has-isAlive? then else))
-
 (defn alive? [p]
-  (if-has-isAlive
-      (.isAlive ^java.lang.Process (:proc p))
-    (throw (ex-info "The `alive?` function is not supported before JDK 8" {}))))
+  (.isAlive ^java.lang.Process (:proc p)))

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -592,3 +592,17 @@
               (tokenize cmd))
         cmd (into cmd args)]
     (check (process prev cmd (merge default-shell-opts opts)))))
+
+(def ^:private has-isAlive?
+  (boolean (try
+             (.getDeclaredMethod (java.lang.Class/forName "java.lang.Process")
+                                 "isAlive" (into-array java.lang.Class []))
+             (catch Throwable _ false))))
+
+(defmacro ^:private if-has-isAlive [then else]
+  (if has-isAlive? then else))
+
+(defn alive? [p]
+  (if-has-isAlive
+      (.isAlive ^java.lang.Process (:proc p))
+    (throw (ex-info "The `alive?` function is not supported before JDK 8" {}))))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -285,24 +285,12 @@
 
 (jdk9+)
 
-(defmacro ^:private if-have-alive [have-alive no-alive]
-  (if (identical? ::ex (try
-                         (.getDeclaredMethod (java.lang.Class/forName "java.lang.Process")
-                                             "isAlive" (into-array java.lang.Class []))
-                         (catch Throwable _ ::ex)))
-    no-alive
-    have-alive))
-
-(if-have-alive
-    (deftest alive-lives
-      (let [{:keys [in] :as res} (process '[cat])]
-        (is (true? (p/alive? res)))
-        (.close in)
-        @res
-        (is (false? (p/alive? res)))))
-  (deftest alive-throws
-    (let [p (process "echo")]
-      (is (thrown? clojure.lang.ExceptionInfo #"failed" (p/alive? p) "no isAlive method")))))
+(deftest alive-lives
+  (let [{:keys [in] :as res} (process '[cat])]
+    (is (true? (p/alive? res)))
+    (.close in)
+    @res
+    (is (false? (p/alive? res)))))
 
 ;;;; Windows tests
 ;;;; Run with clojure -M:test -i windows

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -285,6 +285,25 @@
 
 (jdk9+)
 
+(defmacro ^:private if-have-alive [have-alive no-alive]
+  (if (identical? ::ex (try
+                         (.getDeclaredMethod (java.lang.Class/forName "java.lang.Process")
+                                             "isAlive" (into-array java.lang.Class []))
+                         (catch Throwable _ ::ex)))
+    no-alive
+    have-alive))
+
+(if-have-alive
+    (deftest alive-lives
+      (let [{:keys [in] :as res} (process '[cat])]
+        (is (true? (p/alive? res)))
+        (.close in)
+        @res
+        (is (false? (p/alive? res)))))
+  (deftest alive-throws
+    (let [p (process "echo")]
+      (is (thrown? clojure.lang.ExceptionInfo #"failed" (p/alive? p) "no isAlive method")))))
+
 ;;;; Windows tests
 ;;;; Run with clojure -M:test -i windows
 


### PR DESCRIPTION
I saw a couple of options for detecting features in process.cljc and chose the more explicit one.

I'm not sure how to test pre-JDK8 behavior when `.isAlive` is not available. Does babushka/process explicitly support pre-JDK 8? If so, any recommendations on how to test?
