### PR TITLE
Fix more example code to match the expected output

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ setting which defaults to writing to a stream:
 ``` clojure
 user=> (let [stream (-> (process "ls") :out)]
          @(process {:in stream
-                    :out :inherit} "cat")
-         nil)
+                    :out :string} "cat")
+         :out
+         println)
 API.md
 CHANGELOG.md
 LICENSE


### PR DESCRIPTION
From the original doc, when trying I got the following:

```clojure
  (let [stream (-> (process "ls") :out)]
    (-> @(process {:in stream
                   :out :inherit} "cat")))
```
Result:

```
  {:proc #object[java.lang.ProcessImpl 0x1aba10d0 "Process[pid=9447, exitValue=0]"], :exit 0, :in #object[java.lang.ProcessImpl$ProcessPipeOutputStream 0x6068170f "java.lang.ProcessImpl$ProcessPipeOutputStream@6068170f"], :out #object[java.lang.ProcessBuilder$NullInputStream 0x6110634e "java.lang.ProcessBuilder$NullInputStream@6110634e"], :err #object[java.lang.ProcessImpl$ProcessPipeInputStream 0x49484543 "java.lang.ProcessImpl$ProcessPipeInputStream@49484543"], :prev nil, :cmd ["cat"]}
```
Changing from `:out :inherit` to `:out :string` and threads it to `:out` seems to produce the expected result in the doc (as list of strings with `\n`)