### PR TITLE
Support redirecting stderr to stdout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
             chmod +x linux-install-1.10.3.1040.sh
             sudo ./linux-install-1.10.3.1040.sh
       - run:
+          name: Download deps
+          command: |
+            clojure -P
+      - run:
           name: Run JVM tests
           command: |
             script/test
@@ -51,6 +55,10 @@ jobs:
             chmod +x linux-install-1.10.3.1040.sh
             sudo ./linux-install-1.10.3.1040.sh
       - run:
+          name: Download deps
+          command: |
+            clojure -P
+       - run:
           name: Run JVM tests
           command: |
             script/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
             chmod +x linux-install-1.10.3.1040.sh
             sudo ./linux-install-1.10.3.1040.sh
       - run:
-          name: Download deps
+          name: Install Babashka
           command: |
-            clojure -P
+            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
       - run:
           name: Run JVM tests
           command: |
@@ -55,10 +55,10 @@ jobs:
             chmod +x linux-install-1.10.3.1040.sh
             sudo ./linux-install-1.10.3.1040.sh
       - run:
-          name: Download deps
+          name: Install Babashka
           command: |
-            clojure -P
-       - run:
+            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+      - run:
           name: Run JVM tests
           command: |
             script/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,7 @@ jobs:
       uses: DeLaGuardo/setup-clojure@10.3
       with:
         cli: 1.10.3.1040
-
-    - name: Download deps
-      run: |
-        clojure -P -M:clj-1.9
-        clojure -P -M:clj-1.10
-        clojure -P -M:clj-1.11
+        bb: 'latest'
 
     - name: Run tests not Windows
       if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,15 @@ jobs:
         restore-keys: "${{ runner.os }}-deps-"
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@3.6
+      uses: DeLaGuardo/setup-clojure@10.3
       with:
         cli: 1.10.3.1040
+
+    - name: Download deps
+      run: |
+        clojure -P -M:clj-1.9
+        clojure -P -M:clj-1.10
+        clojure -P -M:clj-1.11
 
     - name: Run tests not Windows
       if: ${{ matrix.os != 'windows-latest' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 [Babashka process](https://github.com/babashka/process)
 Clojure library for shelling out / spawning sub-processes
 
+## Unreleased
+
+- [#113](https://github.com/babashka/process/issues/113): Support redirecting stderr to stdout ([@lread](https://github.com/lread))
+
 ## 0.4.16
 
 - [#100](https://github.com/babashka/process/issues/100): preserve single-quotes in double-quoted string

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ user=> (-> (shell {:out :string} "ls -la") :out str/split-lines first)
 "total 144"
 ```
 
+To also capture stderr to a `:string`, add in the `:err :string` option:
+
+``` clojure
+user=> (-> (shell {:out :string :err :string} "git conpig user.name")
+           (select-keys [:out :err]))
+{:out "borkdude\n", :err "WARNING: You called a Git command named 'conpig', which does not exist.\nContinuing in -1.1 seconds, assuming that you meant 'config'.\n"}
+```
+
+To redirect stderr to stdout specify the `:err :out` option:
+
+``` clojure
+user=> (-> (shell {:out :string :err :out} "git conpig user.name") :out)
+"WARNING: You called a Git command named 'conpig', which does not exist.\nContinuing in -1.1 seconds, assuming that you meant 'config'.\nborkdude\n"
+```
+
 To change the working directory, use the `:dir` option:
 
 ``` clojure

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -251,6 +251,7 @@
        :append (.redirectOutput pb (ProcessBuilder$Redirect/appendTo (io/file out-file)))
        nil)
      (case err
+       :out (.redirectErrorStream pb true)
        :inherit (.redirectError pb ProcessBuilder$Redirect/INHERIT)
        :write (.redirectError pb (ProcessBuilder$Redirect/to (io/file err-file)))
        :append (.redirectError pb (ProcessBuilder$Redirect/appendTo (io/file err-file)))
@@ -421,6 +422,7 @@
       The `:out` and `:err` options support `:string` for writing to a string
       output. You will need to `deref` the process before accessing the string
       via the process's `:out`.
+      To redirect `:err` to `:out`, specify `:err :out`.
       For writing output to a file, you can set `:out` and `:err` to a `java.io.File` object, or a keyword:
        - `:write` + an additional `:out-file`/`:err-file` + file to write to the file.
        - `:append` + an additional `:out-file`/`:err-file` + file to append to the file.

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -92,7 +92,7 @@
       (is (= 0 ret))
       (is (= "foo" (slurp out)))))
   (testing "redirect :err to :out"
-    (let [test-cmd "clojure -M -e '(println :to-stdout)(binding [*out* *err*] (println :to-stderr))'"]
+    (let [test-cmd "bb -cp '' -e '(println :to-stdout)(binding [*out* *err*] (println :to-stderr))'"]
       (testing "baseline"
         (let [res @(process {:out :string :err :string} test-cmd)]
           (is (= ":to-stdout\n" (:out res)))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -91,6 +91,20 @@
           ret (:exit @proc)]
       (is (= 0 ret))
       (is (= "foo" (slurp out)))))
+  (testing "redirect :err to :out"
+    (let [test-cmd "clojure -M -e '(println :to-stdout)(binding [*out* *err*] (println :to-stderr))'"]
+      (testing "baseline"
+        (let [res @(process {:out :string :err :string} test-cmd)]
+          (is (= ":to-stdout\n" (:out res)))
+          (is (= ":to-stderr\n" (:err res)))))
+      (testing "redirect"
+        (let [res @(process {:out :string :err :out} test-cmd)
+              out-string (:out res)
+              err-null-input-stream (:err res)]
+          (is (= ":to-stdout\n:to-stderr\n" out-string))
+          (is (instance? java.io.InputStream err-null-input-stream))
+          (is (= 0 (.available err-null-input-stream)))
+          (is (= -1 (.read err-null-input-stream)))))))
   (testing "copy output to *out*"
     (let [s (with-out-str
               @(process '[cat] {:in "foo" :out *out*}))]


### PR DESCRIPTION
New tests launch clojure to as part of testing capturing stderr. Adjusted CI to download clojure deps before running tests so we did not pollute stderr with clojure's `Downloading: org/clojure...` stderr messages.

Bumped GitHub action setup-clojure. Prior to bump installed clojure was not launching in GitHub Actions default Windows shell.

Closes #113