### PR TITLE
ci: address warnings from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
     - name: "Checkout code"
-      uses: "actions/checkout@v2"
+      uses: "actions/checkout@v3"
 
     - name: Prepare java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        distribution: "adopt"
+        distribution: "temurin"
         java-version: ${{ matrix.java-version }}
 
     - name: "Restore Cache"
-      uses: "actions/cache@v1"
+      uses: "actions/cache@v3"
       with:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}"


### PR DESCRIPTION
Of note: setup-java task docs recommend switching from adopt distribution to temurin, so did that too.

Closes #114