### PR TITLE
test: include full coverage for windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           name: Install Babashka
           command: |
             sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+            bb --version
       - run:
           name: Run JVM tests
           command: |
@@ -58,6 +59,7 @@ jobs:
           name: Install Babashka
           command: |
             sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+            bb --version
       - run:
           name: Run JVM tests
           command: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         java-version: ["8", "11", "17"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -24,9 +25,11 @@ jobs:
     - name: "Restore Cache"
       uses: "actions/cache@v3"
       with:
-        path: "~/.m2/repository"
-        key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn') }}"
-        restore-keys: "${{ runner.os }}-deps-"
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn','bb.edn') }}"
 
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@10.3
@@ -34,18 +37,12 @@ jobs:
         cli: 1.10.3.1040
         bb: 'latest'
 
-    - name: Run tests not Windows
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: |
-        clojure -M:clj-1.9:test -e windows
-        clojure -M:clj-1.10:test -e windows
-        clojure -M:clj-1.11:test -e windows
-      shell: bash
+    - name: Download bb deps
+      run:
+        bb --version
 
-    - name: Run tests on Windows
-      if: ${{ matrix.os == 'windows-latest' }}
+    - name: Run tests
       run: |
-        clojure -M:clj-1.9:test -i windows
-        clojure -M:clj-1.10:test -i windows
-        clojure -M:clj-1.11:test -i windows
-      shell: powershell
+        clojure -M:clj-1.9:test
+        clojure -M:clj-1.10:test
+        clojure -M:clj-1.11:test

--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ The `:env` option replaces your entire environment with the provided map. To add
 For example, `"PATH"` will not update the value of `"Path"` on Windows.
 Here's an [example of a babashka task](https://github.com/babashka/fs/blob/3b8010d1a0db166771ac7f47573ea09ed45abe33/bb.edn#L10-L11) that understands this nuance.
 
+> **:env TIP**: An OS might have default environment variables it always includes.
+For example, as of this writing, Windows always includes `SystemRoot` and macOS always includes `__CF_USER_TEXT_ENCODING`.
+
 ## Pipelines
 
 The `pipeline` function returns a

--- a/script/test
+++ b/script/test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -M:test -e windows @$
+clojure -M:test @$

--- a/script/wd.clj
+++ b/script/wd.clj
@@ -1,0 +1,27 @@
+;; wd - wee dummy - an os-agnostic bb script launched by our unit tests
+(require '[clojure.java.io :as io]
+         '[clojure.string :as str])
+
+;; usage
+;; :out <somestring> - dump <somestring> to stdout
+;; :err <somestring> - dump <somestring> to stderr
+;; :ls <somefile> - dir of <somefile> to stdout
+;; :env - dump env to stdout
+;; :grep <somestring> - returns all lines from stdin matching <somestring>
+;; :upper - read and emit lines from stdin, but converted to uppercase
+;; :exit <someval> - exits with <someval>
+
+;; the naivest of cmd line parsing
+(doseq [[cmd val] (partition-all 2 1 *command-line-args*)]
+  (case cmd
+    ":out" (println val)
+    ":err" (binding [*out* *err*] (println val))
+    ":ls" (pr (->> val io/file (.listFiles) (map str) sort))
+    ":env" (pr (->> (System/getenv) (into {})))
+    ":grep" (doseq [l (->> *in* io/reader line-seq (filter #(str/includes? % val)))]
+              (println l))
+    ":upper" (doseq [l (->> *in* io/reader line-seq)]
+               (println (str/upper-case l)))
+    ":sleep" (Thread/sleep (parse-long val))
+    ":exit" (System/exit (parse-long val))
+    nil))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -1,12 +1,73 @@
 (ns babashka.process-test
   (:require [babashka.fs :as fs]
             [babashka.process :refer [tokenize process check sh $ pb start] :as p]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.test :as t :refer [deftest is testing]]))
 
+(defn- *find-bb
+  "Find bb on path else in current directory.
+  Return unresolved bb, it is the job of babashka process, at least on Windows to resolve the exe."
+  []
+  (or (and (fs/which "bb") "bb")
+      (and (fs/which "./bb") "./bb")))
+
 (println "Testing clojure version:" (clojure-version))
+(println "Calling babashka as:" (if-let [bb (*find-bb)]
+                                  (format "%s (resolves to: %s)" bb (fs/which bb))
+                                  "<not found>"))
+
+(def ^:private wd
+  "Wee dummy script location. Understands that these tests are run from babashka/process or babashka."
+  (->> ["process/script/wd.clj"
+        "script/wd.clj"]
+       (filter fs/exists?)
+       first))
+
+(def ^:private os
+  "Sometimes we need to know if we are running on macOS, in those cases fs/windows? does not cut it"
+  (condp re-find (str/lower-case (System/getProperty "os.name"))
+    #"win" :win
+    #"mac" :mac
+    #"(nix|nux|aix)" :unix
+    #"sunos" :solaris
+    :unknown))
+
+(def ^:private always-present-env-vars
+  "Even when requesting an empty environment, some OSes do not return an empty environment"
+  {:mac ["__CF_USER_TEXT_ENCODING"]
+   :win ["SystemRoot"]})
+
+(defn- ols
+  "Return s with line separators converted for current operating system"
+  [s]
+  (str/replace s "\n" (System/getProperty "line.separator")))
+
+(defn- resolve-exe
+  "For the purposes of these tests, we sometimes need to expect how babashka process will resolve an exe for :cmd."
+  [exe]
+  (if (fs/windows?)
+    (-> exe fs/which str)
+    exe))
+
+(defn- find-bb
+  "Tests launch an os-agnostic bb script that emits/behaves in ways useful
+  to exercising babashka.process. Any test that uses bb should find it via
+  this function.
+
+  Babashka proper also runs these tests under the jvm and native-image.
+  For babashka proper jvm tests, bb does not exist in the CI environment.
+  This function allows jvm tests to be skipped without error in this scenario.
+  This is fine because jvm tests are simply a pre-cursor/quick-way to run tests
+  before they are repeated for native-image where any test failures will ultimately
+  be caught."
+  []
+  (or (*find-bb)
+      (if (= "jvm" (System/getenv "BABASHKA_TEST_ENV"))
+        (println "WARNING: Skipping test because bb not found in path or current dir.")
+        (throw (ex-info "ERROR: bb not found in path or current dir" {})))))
 
 (deftest tokenize-test
   (is (= [] (tokenize "")))
@@ -35,15 +96,17 @@
 #?(:bb nil
    :clj
    (deftest parse-args-test
-     (let [norm (p/parse-args [(p/process "echo hello") "cat"])]
-       (is (instance? babashka.process.Process (:prev norm)))
-       (is (= ["cat"] (:cmd norm))))
-     (let [norm (p/parse-args [(p/process "echo hello") ["cat"] {:out :string}])]
-       (is (instance? babashka.process.Process (:prev norm)))
-       (is (= ["cat"] (:cmd norm)))
-       (is (= {:out :string} (:opts norm))))
+     (when-let [bb (find-bb)]
+       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb wd)) "cat"])]
+         (is (instance? babashka.process.Process (:prev norm)))
+         (is (= ["cat"] (:cmd norm))))
+       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb wd))
+                                 ["cat"] {:out :string}])]
+         (is (instance? babashka.process.Process (:prev norm)))
+         (is (= ["cat"] (:cmd norm)))
+         (is (= {:out :string} (:opts norm)))))
      (is (= ["foo" "bar" "baz"] (:cmd (p/parse-args ["foo bar" "baz"]))))
-     (let [norm (p/parse-args [{:out :string } "foo bar" "baz"])]
+     (let [norm (p/parse-args [{:out :string} "foo bar" "baz"])]
        (is (= ["foo" "bar" "baz"] (:cmd norm)))
        (is (= {:out :string} (:opts norm))))
      (testing "existing file invocation"
@@ -57,224 +120,274 @@
   code in a delay. Waiting for the process to end happens through realizing the
   delay. Waiting also happens implicitly by not specifying :stream, since
   realizing :out or :err needs the underlying process to finish."
-    (let [res (process ["ls"])
-          out (slurp (:out res))
-          err (slurp (:err res))
-          checked (check res) ;; check should return process with :exit code
-          ;; populated
-          exit (:exit checked)]
-      (is (string? out))
-      (is (string? err))
-      (is (not (str/blank? out)))
-      (is (str/blank? err))
-      (is (number? exit))
-      (is (zero? exit)))))
+    (when-let [bb (find-bb)]
+      (let [res (process [bb wd ":out" "hello"])
+            out (slurp (:out res))
+            err (slurp (:err res))
+            checked (check res) ;; check should return process with :exit code
+            ;; populated
+            exit (:exit checked)]
+        (is (= (ols "hello\n") out))
+        (is (string? err))
+        (is (str/blank? err))
+        (is (number? exit))
+        (is (zero? exit))))))
 
 (deftest process-wait-realize-with-stdin-test
   (testing "When specifying :out and :err both a non-strings, the process keeps
   running. :in is the stdin of the process to which we can write. Calling close
   on that stream closes stdin, so a program like cat will exit. We wait for the
   process to exit by realizing the exit delay."
-    (let [res (process '[cat] {:err :inherit})
-          _ (is (true? (.isAlive (:proc res))))
-          in (:in res)
-          w (io/writer in)
-          _ (binding [*out* w]
-              (println "hello"))
-          _ (.close in)
-          exit (:exit @res)
-          _ (is (zero? exit))
-          _ (is (false? (.isAlive (:proc res))))
-          out-stream (:out res)]
-      (is (= "hello\n" (slurp out-stream))))))
+    (when-let [bb (find-bb)]
+      (let [res (process [(symbol bb) (symbol wd) ':upper] {:err :inherit})
+            _ (is (true? (.isAlive (:proc res))))
+            in (:in res)
+            w (io/writer in)
+            _ (binding [*out* w]
+                (println "hello"))
+            _ (.close in)
+            exit (:exit @res)
+            _ (is (zero? exit))
+            _ (is (false? (.isAlive (:proc res))))
+            out-stream (:out res)]
+        (is (= (ols "HELLO\n") (slurp out-stream)))))))
 
 (deftest process-copy-input-from-string-test
-  (let [proc (process '[cat] {:in "foo"})
-        out (:out proc)
-        ret (:exit @proc)]
-    (is (= 0 ret))
-    (is (= "foo" (slurp out)))))
+  (when-let [bb (find-bb)]
+    (let [proc (process [(symbol bb) (symbol wd) ':upper] {:in "foo"})
+          out (:out proc)
+          ret (:exit @proc)]
+      (is (= 0 ret))
+      (is (= (ols "FOO\n") (slurp out))))))
 
 (deftest process-redirect-err-out-test
-  (let [bb (fs/which "bb")
-        bb (or bb (if (fs/windows?)
-                    "bb.exe"
-                    "./bb"))
-        bb (if (fs/exists? bb)
-             bb
-             (println "WARNING: Skipping tests because bb not installed"))]
-    (when bb
-      (let [test-cmd (format "%s -cp '' -e '(println :to-stdout)(binding [*out* *err*] (println :to-stderr))'"
-                             bb)]
-        (testing "baseline"
-          (let [res @(process {:out :string :err :string} test-cmd)]
-            (is (= ":to-stdout\n" (:out res)))
-            (is (= ":to-stderr\n" (:err res)))))
-        (testing "redirect"
-          (let [res @(process {:out :string :err :out} test-cmd)
-                out-string (:out res)
-                err-null-input-stream (:err res)]
-            (is (= ":to-stdout\n:to-stderr\n" out-string))
-            (is (instance? java.io.InputStream err-null-input-stream))
-            (is (= 0 (.available err-null-input-stream)))
-            (is (= -1 (.read err-null-input-stream)))))))))
+  (when-let [bb (find-bb)]
+    (let [test-cmd (format "%s -cp '' %s :out :to-stdout :err :to-stderr"
+                           bb wd)]
+      (testing "baseline"
+        (let [res @(process {:out :string :err :string} test-cmd)]
+          (is (= (ols ":to-stdout\n") (:out res)))
+          (is (= (ols ":to-stderr\n") (:err res)))))
+      (testing "redirect"
+        (let [res @(process {:out :string :err :out} test-cmd)
+              out-string (:out res)
+              err-null-input-stream (:err res)]
+          (is (= (ols ":to-stdout\n:to-stderr\n") out-string))
+          (is (instance? java.io.InputStream err-null-input-stream))
+          (is (= 0 (.available err-null-input-stream)))
+          (is (= -1 (.read err-null-input-stream))))))))
 
 (deftest process-copy-to-out-test
-  (let [s (with-out-str
-            @(process '[cat] {:in "foo" :out *out*}))]
-    (is (= "foo" s))))
+  (when-let [bb (find-bb)]
+    (let [s (with-out-str
+              @(process [(symbol bb) (symbol wd) ':upper] {:in "foo" :out *out*}))]
+      (is (= (ols "FOO\n") s)))))
 
 (deftest process-copy-stderr-to-out-test
-  (let [s (with-out-str
-            (-> (process '[curl "foo"] {:err *out*})
-                deref :exit))]
-    (is (pos? (count s)))))
+  (when-let [bb (find-bb)]
+    (let [s (with-out-str
+              (-> (process [(symbol bb) (symbol wd) ':err 'foo] {:err *out*})
+                  deref :exit))]
+      (is (= (ols "foo\n") s)))))
 
 (deftest process-chaining-test
-  (is (= "README.md\n"
-         (-> (process ["ls"])
-             (process ["grep" "README.md"]) :out slurp)))
-  (is (= "README.md\n"
-         (-> (sh ["ls"])
-             (sh ["grep" "README.md"]) :out))))
+  (when-let [bb (find-bb)]
+    (is (= (ols "README.md\n")
+           (-> (process [bb wd ":out" "foo" ":out" "README.md" ":out" "bar"])
+               (process [bb wd ":grep" "README.md"]) :out slurp)))
+    (is (= (ols "README.md\n")
+           (-> (sh [bb wd ":out" "foo" ":out" "README.md" ":out" "bar"])
+               (sh [bb wd ":grep" "README.md"]) :out)))))
 
 (deftest process-dir-option-test
-  (is (= (-> (process ["ls"]) :out slurp)
-         (-> (process ["ls"] {:dir "."}) :out slurp)))
-  ;; skip this test when ran from babashka lib tests
-  (when (.exists (io/file "src" "babashka" "process.cljc"))
-    (is (= (-> (process ["ls"] {:dir "test/babashka"}) :out slurp)
-           "process_test.cljc\n")))
-  (is (not= (-> (process ["ls"]) :out slurp)
-            (-> (process ["ls"] {:dir "test/babashka"}) :out slurp))))
+  (when-let [bb (find-bb)]
+    (let [out (-> (process [bb wd ":ls" "."]) :out slurp)]
+      (is (str/includes? out "README.md"))
+      (is (= out
+             (-> (process [bb wd ":ls" "."] {:dir "."}) :out slurp))))
+
+    (let [subdir (if (= "script/wd.clj" wd) ;; handle running from babashka vs babashka/process
+                   "test/babashka"
+                   "process/test/babashka")
+          rel (str/replace subdir #"[^/]+" "..")
+          rel-wd (str rel "/" wd)
+          rel-bb (if (= "./bb" bb)
+                   (str rel "/bb")
+                   bb)]
+      (let [out1 (-> (process [bb wd ":ls" "."]) :out slurp)
+            out2 (-> (process [rel-bb rel-wd ":ls" "."] {:dir subdir})
+                     :out slurp)]
+        (is (str/includes? out1 "README.md"))
+        (is (str/includes? out2 "process_test.cljc"))
+        (is (not= out1 out2))))))
 
 (deftest process-env-option-test
-  (is (= "" (-> (process ["env"] {:env {}}) :out slurp)))
-  (let [out (-> (sh "env" {:extra-env {:FOO "BAR"}}) :out)]
-    (is (str/includes? out "PATH"))
-    (is (str/includes? out "FOO=BAR")))
-  (is (= ["SOME_VAR=SOME_VAL"
-          "keyword_val=:keyword-val"
-          "keyword_var=KWVARVAL"]
-         (-> (process ["env"] {:env {"SOME_VAR" "SOME_VAL"
+  (when-let [bb (find-bb)]
+    (testing "request an empty env"
+      ;; using -cp "" for bb here, otherwise it will expect JAVA_HOME env var to be set
+      (let [vars (-> (process [bb "-cp" "" wd ":env"] {:env {}})
+                     :out
+                     slurp
+                     edn/read-string)
+            expected-vars (os always-present-env-vars)]
+        (is (= expected-vars (keys vars)))))
+    (testing "add to existing env"
+      (let [out (-> (sh (format "%s %s :env" bb wd) {:extra-env {:FOO "BAR"}})
+                    :out)]
+        (is (str/includes? out "PATH"))
+        (is (str/includes? out "\"FOO\" \"BAR\""))))
+    (testing "request a specific env"
+      ;; using -cp "" for bb here, otherwise it will expect JAVA_HOME env var to be set
+      (let [vars (-> (process [bb "-cp" "" wd ":env"]
+                              {:env {"SOME_VAR" "SOME_VAL"
                                      :keyword_var "KWVARVAL"
                                      "keyword_val" :keyword-val}})
-             :out
-             slurp
-             (str/split-lines)
-             (sort)))))
+                     :out
+                     slurp
+                     edn/read-string)
+            added-vars (apply dissoc vars (os always-present-env-vars))]
+        (is (= {"SOME_VAR" "SOME_VAL"
+                "keyword_val" ":keyword-val"
+                "keyword_var" "KWVARVAL"}
+               added-vars))))))
 
 (deftest process-check-throws-on-non-zero-exit-test
-  (let [err-form '(binding [*out* *err*]
-                    (println "error123")
-                    (System/exit 1))]
+  (when-let [bb (find-bb)]
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo #"error123"
-          (-> (process ["clojure" "-e" (str err-form)]) (check)))
-        "with :err string"))
-  (is (thrown?
-        clojure.lang.ExceptionInfo #"failed"
-        (-> (process ["clojure" "-e" (str '(System/exit 1))])
-            (check)))
-      "With no :err string")
-  (is (thrown?
-        clojure.lang.ExceptionInfo #"failed"
-        (-> (process ["clojure" "-e" (str '(System/exit 1))] {:err *err*})
-            (check)))
-      "With :err set to *err*")
-  (testing "and the exception"
-    (let [command ["clojure" "-e" (str '(System/exit 1))]]
-      (try
-        (-> (process command)
-            (check))
-        (catch clojure.lang.ExceptionInfo e
-          (testing "contains the process arguments"
-            (is (= command (:cmd (ex-data e)))))
-          (testing "and contains a babashka process type"
-            (is (= :babashka.process/error (:type (ex-data e))))))))))
+          (-> (process (format "%s %s :err error123 :exit 1" bb wd))
+              (check)))
+        "with :err string")
+    (is (thrown?
+          clojure.lang.ExceptionInfo #"failed"
+          (-> (process (format "%s %s :exit 1" bb wd))
+              (check)))
+        "With no :err string")
+    (is (thrown?
+          clojure.lang.ExceptionInfo #"failed"
+          (-> (process {:err *err*} (format "%s %s :exit 1" bb wd))
+              (check)))
+        "With :err set to *err*")
+    (testing "and the exception"
+      (let [command [bb wd ":exit" "1"]]
+        (try
+          (-> (process command)
+              (check))
+          (catch clojure.lang.ExceptionInfo e
+            (testing "contains the process arguments"
+              (is (= (assoc command 0 (-> command first resolve-exe))
+                     (:cmd (ex-data e)))))
+            (testing "and contains a babashka process type"
+              (is (= :babashka.process/error (:type (ex-data e)))))))))))
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (deftest process-dollar-macro-test
-  (let [config {:a 1}]
-    (is (= "{:a 1}\n" (-> ($ echo ~config) :out slurp)))
-    (let [sw (java.io.StringWriter.)]
-      (is (= "{:a 1}\n" (do (-> ^{:out sw}
-                                ($ echo ~config)
-                                deref)
-                            (str sw)))))
-    (let [sw (java.io.StringWriter.)]
-      (is (= "{:a 1}\n" (do (-> ($ ~{:out sw} echo ~config)
-                                deref)
-                            (str sw)))))
-    (let [sw (java.io.StringWriter.)]
-      (is (= "{:a 1}\n" (do (-> ($ {:out sw} echo ~config)
-                                deref)
-                            (str sw)))))))
+  (when-let [bb (find-bb)]
+    (let [config {:a 1}]
+      (is (= (ols "{:a 1}\n") (-> ($ ~(symbol bb) ~(symbol wd) :out ~config) :out slurp)))
+      (let [sw (java.io.StringWriter.)]
+        (is (= (ols "{:a 1}\n") (do (-> ^{:out sw}
+                                        ($ ~(symbol bb) ~(symbol wd) :out ~config)
+                                        deref)
+                                    (str sw)))))
+      (let [sw (java.io.StringWriter.)]
+        (is (= (ols "{:a 1}\n") (do (-> ($ ~{:out sw} ~(symbol bb) ~(symbol wd) :out ~config)
+                                        deref)
+                                    (str sw)))))
+      (let [sw (java.io.StringWriter.)]
+        (is (= (ols "{:a 1}\n") (do (-> ($ {:out sw} ~(symbol bb) ~(symbol wd) :out ~config)
+                                        deref)
+                                    (str sw))))))))
 
 (deftest process-same-as-pb-start-test
-  (let [out (-> (process ["ls"]) :out slurp)]
-    (is (and (string? out) (not (str/blank? out))))
-    (is (= out (-> (pb ["ls"]) (start) :out slurp)))))
+  (when-let [bb (find-bb)]
+    (let [cmd [bb wd ":ls" "."]
+          out (-> (process cmd) :out slurp)]
+      (is (and (string? out) (not (str/blank? out))))
+      (is (str/includes? out "README.md"))
+      (is (= out (-> (pb cmd) (start) :out slurp))))))
 
 (deftest process-out-to-string-test
-  (is (string? (-> (process ["ls"] {:out :string})
-                   check
-                   :out))))
+  (when-let [bb (find-bb)]
+    (is (= (ols "hello\n") (-> (process [bb wd ":out" "hello"] {:out :string})
+                               check
+                               :out)))))
 
 (deftest process-tokenization-test
-  (is (string? (-> (process "ls -la" {:out :string})
-                   check
-                   :out)))
-  (is (string? (-> ^{:out :string} ($ "ls -la" )
-                   check
-                   :out)))
-  (is (string? (-> (sh "ls -la")
-                   :out))))
-#?(:bb nil
+  (when-let [bb (find-bb)]
+    (is (= (ols "hello\n") (-> (process (format "%s %s :out hello" bb wd) {:out :string})
+                               check
+                               :out)))
+    ;; This bit of awkwardness might be avoidable.
+    ;; But if we needing to test ($ "literal string") maybe not.
+    (is (= (ols "hello\n") (-> (case bb
+                                 "bb"
+                                 (case wd
+                                   "script/wd.clj" ^{:out :string} ($ "bb script/wd.clj :out hello")
+                                   "process/script/wd.clj" ^{:out :string} ($ "bb process/script/wd.clj :out hello"))
+                                 "./bb"
+                                 (case wd
+                                   "script/wd.clj" ^{:out :string} ($ "./bb script/wd.clj :out hello")
+                                   "process/script/wd.clj" ^{:out :string} ($ "./bb process/script/wd.clj :out hello") ))
+                               check
+                               :out)))
+    (is (= (ols "hello\n") (-> (sh (format "%s %s :out hello" bb wd))
+                               :out)))))
+
+(deftest process-space-in-cmd-test
+  (when-let [bb (find-bb)]
+    (let [proc @(p/process [(str bb " ") wd ":out" "hello"] {:out :string})]
+      (is (= (ols "hello\n") (:out proc)))
+      (is (zero? (:exit proc))))))
+
+#?(:bb nil ;; skip longer running test when running form babashka proper
    :clj
    (deftest process-deref-timeout-test
-     (is (= ::timeout (deref (process ["clojure" "-e" "(Thread/sleep 500)"]) 250 ::timeout)))
-     (is (= 0 (:exit (deref (process ["ls"]) 250 nil))))))
+     (when-let [bb (find-bb)]
+       (is (= ::timeout (deref (process [bb wd ":sleep" "500"]) 250 ::timeout)))
+       (is (= 0 (:exit (deref (process [bb wd]) 250 nil)))))))
 
 (deftest shell-test
-  (is (str/includes? (:out (p/shell {:out :string} "echo hello")) "hello"))
-  (is (str/includes? (-> (p/shell {:out :string} "echo hello")
-                         (p/shell {:out :string } "cat")
-                         :out)
-                     "hello"))
-  (is (= 1 (do (p/shell {:continue true} "ls nothing") 1))))
+  (when-let [bb (find-bb)]
+    (is (str/includes? (:out (p/shell {:out :string} (format "%s %s :out hello" bb wd))) "hello"))
+    (is (str/includes? (-> (p/shell {:out :string} (format "%s %s :out hello" bb wd))
+                           (p/shell {:out :string } (format "%s %s :upper" bb wd))
+                           :out)
+                       "HELLO"))
+    (is (= 1 (do (p/shell {:continue true} (format "%s %s :exit 1" bb wd)) 1)))))
 
+
+#_{:clj-kondo/ignore [:unused-binding]}
 (deftest dollar-pipe-test
-  (is (str/includes?
-       (-> ($ ls -la)
-           ($ {:out :string} cat) deref :out)
-       "total"))
-  (is (str/includes?
-       (-> ($ ls -la)
-           ^{:out :string} ($ cat) deref :out)
-       "total"))
-  (is (= "hello\nhello\n"
-         (-> ($ echo hello) ($ sed p) deref :out slurp))))
+  (when-let [bb (find-bb)]
+    (is (= (ols "HELLO\n")
+           (-> ($ ~(symbol bb) ~(symbol wd) :out hello)
+               ($ {:out :string} ~(symbol bb) ~(symbol wd) :upper) deref :out)))
+    (is (= (ols "HELLO\n")
+           (-> ($ ~(symbol bb) ~(symbol wd) :out hello)
+               ^{:out :string} ($ ~(symbol bb) (symbol wd) :upper) deref :out)))
+    (is (= (ols "hello\n")
+           (-> ($ ~(symbol bb) ~(symbol wd) :out goodbye :out hello)
+               ($ ~(symbol bb) ~(symbol wd) :grep hello) deref :out slurp)))))
 
 (deftest redirect-file-test
-  (fs/with-temp-dir [tmp {}]
-    (let [out (fs/file tmp "out.txt")]
-      @(p/process "echo hello" {:out :write
-                                :out-file out})
-      (is (str/starts-with? (slurp out) "hello"))
-      @(p/process "echo hello" {:out :append
-                                :out-file out})
-      (is (= 2 (count (re-seq #"hello" (slurp out)))))))
-  (fs/with-temp-dir [tmp {}]
-    (let [out (fs/file tmp "err.txt")]
-      @(p/process "bash -c '>&2 echo \"error\"'"
-                  {:err :write
-                   :err-file out})
-      (is (str/starts-with? (slurp out) "error"))
-      @(p/process "bash -c '>&2 echo \"error\"'"
-                  {:err :append
-                   :err-file out})
-      (is (= 2 (count (re-seq #"error" (slurp out))))))))
+  (when-let [bb (find-bb)]
+    (fs/with-temp-dir [tmp {}]
+      (let [out (fs/file tmp "out.txt")]
+        @(p/process (format "%s %s :out hello" bb wd)
+                    {:out :write :out-file out})
+        (is (= (ols "hello\n") (slurp out)))
+        @(p/process (format "%s %s :out goodbye" bb wd)
+                    {:out :append :out-file out})
+        (is (= (ols "hello\ngoodbye\n") (slurp out)))))
+    (fs/with-temp-dir [tmp {}]
+      (let [out (fs/file tmp "err.txt")]
+        @(p/process (format "%s %s :err 'err,hello'" bb wd)
+                    {:err :write :err-file out})
+        (is (= (ols "err,hello\n") (slurp out)))
+        @(p/process (format "%s %s :err 'grrr-oodbye'" bb wd)
+                    {:err :append :err-file out})
+        (is (= (ols "err,hello\ngrrr-oodbye\n") (slurp out)))))))
 
 (deftest pprint-test
   ;; #?(:bb nil ;; in bb we already required the babashka.process.pprint namespace
@@ -282,114 +395,99 @@
   ;;    (testing "calling pprint on a process without requiring pprint namespace causes exception (ambiguous on pprint/simple-dispatch multimethod)"
   ;;      (is (thrown-with-msg? IllegalArgumentException #"Multiple methods in multimethod 'simple-dispatch' match dispatch value"
   ;;                            (-> (process "cat missing-file.txt") pprint)))))
-  (testing "after requiring pprint namespace, process gets pprinted as a map"
-    (do
-      (require '[babashka.process] :reload '[babashka.process.pprint] :reload)
-      (is (str/includes? (with-out-str (-> (process "cat missing-file.txt") pprint)) ":proc")))))
+  (when-let [bb (find-bb)]
+    (testing "after requiring pprint namespace, process gets pprinted as a map"
+      (do
+        (require '[babashka.process] :reload '[babashka.process.pprint] :reload)
+        (is (str/includes? (with-out-str (-> (process (format "%s %s :out hello" bb wd)) pprint)) ":proc"))))))
 
 (deftest pre-start-fn-test
-  (testing "a print fn option gets executed just before process is started"
-    (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}]
-      (is (str/includes? (with-out-str (process "ls" p))
-            "Running ls"))
-      (is (str/includes? (with-out-str (sh "cat foo" p))
-            "Running cat foo")))))
+  (when-let [bb (find-bb)]
+    (testing "a print fn option gets executed just before process is started"
+      (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}
+            resolved-bb (resolve-exe bb)]
+        (is (= (ols (format "Running %s %s :out hello1\n" resolved-bb wd))
+               (with-out-str (process (format "%s %s :out hello1" bb wd) p))))
+        (is (= (ols (format "Running %s %s :out hello2\n" resolved-bb wd))
+               (with-out-str (-> (pb [bb wd ":out" "hello2"] p) start))))
+        (is (= (ols (format "Running %s %s :exit 32\n" resolved-bb wd))
+               (with-out-str (sh (format "%s %s :exit 32" bb wd) p))))))))
 
 (defmacro ^:private jdk9+ []
-  (if (identical? ::ex
+  (if (identical? ::pre-jdk9
                   (try (import 'java.lang.ProcessHandle)
-                       (catch Exception _ ::ex)))
+                       (catch Exception _ ::pre-jdk9)))
     '(do
        (require '[babashka.process :refer [pipeline]])
-       (deftest pipeline-test
-         (testing "pipeline returns processes nested with ->"
-           (is (= [["ls"] ["cat"]] (map :cmd (pipeline (-> (process ["ls"]) (process ["cat"])))))))))
+       (deftest pipeline-prejdk9-test
+         (when-let [bb (find-bb)]
+           (testing "pipeline returns processes nested with ->"
+             (let [resolved-bb (resolve-exe bb)]
+               (is (= [[resolved-bb wd ":out" "foo"]
+                       [resolved-bb wd ":upper"]]
+                      (map :cmd (pipeline (-> (process [bb wd ":out" "foo"])
+                                              (process [bb wd ":upper"])))))))))))
     '(do
        (require '[babashka.process :refer [pipeline pb]])
        (deftest inherit-test
-         (let [proc (process "echo" {:shutdown p/destroy-tree
-                                     :inherit true})
-               null-input-stream-class (class (:out proc))
-               null-output-stream-class (class (:in proc))]
-           (is (= null-input-stream-class (class (:err proc))))
-           (let [x (process ["cat"] {:shutdown p/destroy-tree
-                                     :inherit true
-                                     :in "foo"})]
-             (is (not= null-output-stream-class (class (:in x))))
-             (is (= null-input-stream-class (class (:out x))))
-             (is (= null-input-stream-class (class (:err x)))))
-           (let [x (process ["cat"] {:shutdown p/destroy-tree
-                                     :inherit true
-                                     :out :string})]
-             (is (= null-output-stream-class (class (:in x))))
-             (is (not= null-input-stream-class (class (:out x))))
-             (is (= null-input-stream-class (class (:err x)))))
-           (let [x (process ["cat"] {:shutdown p/destroy-tree
-                                     :inherit true
-                                     :err :string})]
-             (is (= null-output-stream-class (class (:in x))))
-             (is (= null-input-stream-class (class (:out x))))
-             (is (not= null-input-stream-class (class (:err x)))))))
+         (when-let [bb (find-bb)]
+           (let [proc (process (format "%s %s :out ''" bb wd) {:shutdown p/destroy-tree
+                                                               :inherit true})
+                 null-input-stream-class (class (:out proc))
+                 null-output-stream-class (class (:in proc))]
+             (is (= null-input-stream-class (class (:err proc))))
+             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+                                                :inherit true
+                                                :in "foo"})]
+               (is (not= null-output-stream-class (class (:in x))))
+               (is (= null-input-stream-class (class (:out x))))
+               (is (= null-input-stream-class (class (:err x)))))
+             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+                                                :inherit true
+                                                :out :string})]
+               (is (= null-output-stream-class (class (:in x))))
+               (is (not= null-input-stream-class (class (:out x))))
+               (is (= null-input-stream-class (class (:err x)))))
+             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+                                                :inherit true
+                                                :err :string})]
+               (is (= null-output-stream-class (class (:in x))))
+               (is (= null-input-stream-class (class (:out x))))
+               (is (not= null-input-stream-class (class (:err x))))))))
        (deftest pipeline-test
-         (testing "pipeline returns processes nested with ->"
-           (is (= [["ls"] ["cat"]] (map :cmd (pipeline (-> (process ["ls"]) (process ["cat"])))))))
-         (testing "pipeline returns processes created with pb"
-           (is (= [["ls"] ["cat"]] (map :cmd (pipeline (pb ["ls"]) (pb ["cat"]))))))
-         (testing "pbs can be chained with ->"
-           (let [chain (-> (pb ["ls"]) (pb ["cat"] {:out :string}) start deref)]
-             (is (string? (slurp (:out chain))))
-             (is (= [["ls"] ["cat"]] (map :cmd (pipeline chain)))))))
+         (when-let [bb (find-bb)]
+           (testing "pipeline returns processes nested with ->"
+             (let [resolved-bb (resolve-exe bb)]
+               (is (= [[resolved-bb wd ":out" "foo"]
+                       [resolved-bb wd ":upper"]]
+                      (map :cmd (pipeline (-> (process [bb wd ":out" "foo"])
+                                              (process [bb wd ":upper"]))))))))
+           (testing "pipeline returns processes created with pb"
+             (let [resolved-bb (resolve-exe bb)]
+               (is (= [[resolved-bb wd ":out" "foo"]
+                       [resolved-bb wd ":upper"]]
+                      (map :cmd (pipeline (pb [bb wd ":out" "foo"])
+                                          (pb [bb wd ":upper"])))))))
+           (testing "pbs can be chained with ->"
+             (let [chain (-> (pb [bb wd ":out" "hello"])
+                             (pb [bb wd ":upper"] {:out :string}) start deref)
+                   resolved-bb (resolve-exe bb)]
+               (is (= (ols "HELLO\n") (slurp (:out chain))))
+               (is (= [[resolved-bb wd ":out" "hello"]
+                       [resolved-bb wd ":upper"]] (map :cmd (pipeline chain))))))))
        (deftest exit-fn-test
-         (let [exit-code (promise)]
-           (process ["ls"] {:exit-fn (fn [proc]
-                                       (deliver exit-code (:exit proc)))})
-           (is (int? @exit-code)))))))
+         (when-let [bb (find-bb)]
+           (let [exit-code (promise)]
+             (process [bb wd ":exit" "42"]
+                      {:exit-fn (fn [proc] (deliver exit-code (:exit proc)))})
+             (is (= 42 @exit-code))))))))
 
 (jdk9+)
 
 (deftest alive-lives-test
-  (let [{:keys [in] :as res} (process '[cat])]
-    (is (true? (p/alive? res)))
-    (.close in)
-    @res
-    (is (false? (p/alive? res)))))
-
-;;;; Windows tests
-;;;; Run with clojure -M:test -i windows
-
-(defmacro when-windows [& body]
-  (when (str/starts-with? (System/getProperty "os.name") "Win")
-    `(do ~@body)))
-
-(when-windows
-    (deftest ^:windows windows-executable-resolver-test
-      (when (some-> (resolve 'p/windows?) deref)
-        (prn (-> @(p/process "java --version" {:out :string})
-                 :out))
-        (prn (-> @(p/process ["java" "--version"] {:out :string})
-                 :out)))))
-
-(when-windows
-    (deftest ^:windows windows-invoke-git-with-space-test
-      (let [proc @(p/process ["git " "status"] {:out :string})]
-        (is (string? (:out proc)))
-        (is (zero? (:exit proc))))))
-
-(when-windows
-  (deftest ^:windows windows-pprint-test
-    #_(testing "calling pprint on a process without requiring pprint namespace causes exception (ambiguous on pprint/simple-dispatch multimethod)"
-      (is (thrown-with-msg? IllegalArgumentException #"Multiple methods in multimethod 'simple-dispatch' match dispatch value"
-            (-> (process "cmd /c type missing-file.txt") pprint))))
-    (testing "after requiring pprint namespace, process gets pprinted as a map"
-      (do
-        (require '[babashka.process.pprint])
-        (is (str/includes? (with-out-str (-> (process "cmd /c type missing-file.txt") pprint)) ":proc"))))))
-
-(when-windows
-  (deftest ^:windows windows-pre-start-fn-test
-    (testing "a print fn option gets executed just before process is started"
-      (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}]
-        (is (re-find #"Running .*cmd\.exe .* file\.txt"
-              (with-out-str (process "cmd /c type file.txt" p))))
-        (is (re-find #"Running .*cmd\.exe .* file\.txt"
-              (with-out-str (-> (pb ["cmd" "/c" "type" "file.txt"] p) start))))))))
+  (when-let [bb (find-bb)]
+    (let [{:keys [in] :as res} (process [(symbol bb) (symbol wd) ':upper])]
+      (is (true? (p/alive? res)))
+      (.close in)
+      @res
+      (is (false? (p/alive? res))))))


### PR DESCRIPTION
Instead of launching os specific commands we now launch the os-agnostic wee dummy `test/wd.clj` script via babashka. It is designed to satisfy the needs of tests.

Examples of types of changes to launched processes:
- echo hello -> bb script/wd.clj :out hello
- ls -> bb script/wd.clj :ls .
- grep somestring -> bb script/wd.clj :grep somestring
- clojure -e some-expr -> bb script/wd.clj :out boo :err bah :exit 1

Replaced most uses of `cat` with `bb script/wd.clj :upper`, I felt that transforming the input offered more proof that the process was run successfully.

Because our wee dummy script allows us to define explicit output and behaviour, tests assertions are now also often more explicit.

Took care to keep the args syntax the same as the original test. (i.e. args as string vs vector of strings vs vector of symbols).

CI downloads babashka deps prior to test run. This avoids deps download messages to stderr interfering with the test. A `bb --version` is sufficient.

Removed Windows specific tests, tests are now OS agnostic:
- windows-invoke-git-with-space-test -> process-space-in-cmd-test
- windows-executable-resolver-test -> tested throughout
- windows-pprint-test -> pprint-test
- windows-pre-start-fn-test -> pre-start-fn-test

Understood that tests can be launched from babashka or babashka/process. When tests are run from babashka for the jvm, and bb does not exist, we skip and pass tests that require bb with a warning. These same tests will be run with natively with bb in a subsequent pass, so we are not reducing babashka test coverage.

Updated process-dir-option-test:
- No longer skipping a test assertion when run under babashka.
- Deleted a redundant assertion.

Observations when requesting an empty :env noted in README:
- Windows always includes `SystemRoot`
- macOS always includes `__CF_USER_TEXT_ENCODING`

GitHub Actions changes (could be considered out of scope):
- I set fail-fast to false for the matrix, I found it helpful to all jobs run even after one job had failed.
- I adjusted deps caching to include ~/.deps.clj, I found this helpful in validating my explorations in what deps I needed to pre-download.
- Noticed bb.edn was missing from deps cache key so added it in.

Made some other very minor changes to code/comments for clarity.

Closes #116