### PR TITLE
Resolve relative `program` to `:dir` on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 [Babashka process](https://github.com/babashka/process)
 Clojure library for shelling out / spawning sub-processes
 
+## Unreleased
+
+- [#126](https://github.com/babashka/process/issues/126): Consider `:dir` when resolving relative `program` on Windows ([@lread](https://github.com/lread)) 
+
 ## 0.5.19 (2023-05-11)
 
 - [#124](https://github.com/babashka/process/issues/124): Allow `:cmd` to be passed in map argument

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {babashka/fs {:mvn/version "0.2.12"}}
+{:deps {babashka/fs {:mvn/version "0.4.18"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {cognitect/test-runner
                                {:git/url "https://github.com/cognitect-labs/test-runner"


### PR DESCRIPTION
Java `ProcessBuilder` abstracts, but does not fully generalize, behaviour across underlying OS support for process creation. In the case of Windows, it does not resolve a program relative to the specified working dir. This results in file process creation errors due to the program not being found. This change resolves this nuance.

Bump babashka/fs to get updates to `which`.

Update internal and undocumented program-resolver fn signature. Formerly it expected `program` now it expects map with key `:program` and optionally key `:dir`.

Rewrote dir opt unit tests for better coverage.
We should discover problems when run from babashka.process now rather than accidental coverage offered when running from babashka.

The `exec` function tests are still a work in progress, so did some manual testing by compiling changes into babashka to verify that changes did not break `exec`.

Also: fixed parse-args tests that was spawning os-specific 'ls' command. This test is not run from babashka, so we did not see the failure there, but it did fail locally for me. So switched to os-agnostic wee dummy `wd.clj` script for this one.

Closes #126