### PR TITLE
Update babashka/fs version to 0.4.18

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {babashka/fs {:mvn/version "0.2.12"}}
+{:deps {babashka/fs {:mvn/version "0.4.18"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {cognitect/test-runner
                                {:git/url "https://github.com/cognitect-labs/test-runner"


### PR DESCRIPTION
Bumps `babashka/fs` to latest version. Passing CI tests.