### PR TITLE
Bump fs in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :license {:name "EPL-1.0"
             :url "https://www.eclipse.org/legal/epl-1.0/"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [babashka/fs "0.2.12"]]
+                 [babashka/fs "0.4.18"]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_user
                                     :password :env/clojars_pass


### PR DESCRIPTION
fs was bumped in deps.edn but not project.clj

babashka.process still currently uses project.clj to release to clojars.

Addendum to #126 and #128.