### PR TITLE
Add test support for `exec`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,69 +1,180 @@
-# Clojure CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-clojure/ for more details
-#
 version: 2.1
+
+orbs:
+  win: circleci/windows@5.0.0
+
+executors:
+  linux:
+    docker:
+      - image: cimg/openjdk:17.0
+    working_directory: ~/repo
+    resource_class: large
+  macos:
+    macos:
+      xcode: 14.3
+    working_directory: ~/repo
+  windows:
+    machine:
+      image: windows-server-2019-vs2019:stable
+      resource_class: windows.medium
+      shell: powershell.exe -ExecutionPolicy Bypass
+    working_directory: ~/repo
+
+aliases:
+  - &restore_deps_cache
+    restore_cache:
+      name: "Restore deps cache"
+      keys:
+        - &deps_cache_key v2-dependencies-{{ arch }}-{{ checksum "project.clj" }}-{{ checksum "deps.edn" }}-{{ checksum "bb.edn" }}
+        - v2-dependencies-{{ arch }}
+  - &save_deps_cache
+    save_cache:
+      name: "Save deps cache"
+      key: *deps_cache_key
+      paths:
+        - ~/.m2
+        - ~/.gitlibs
+        - ~/.deps.clj
+  - &restore_tools_cache
+    restore_cache:
+      name: "Restore tools cache"
+      keys:
+        - &tools_cache_key v3-tools-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}
+        # no fallback only restore exact match on match
+  - &save_tools_cache
+    save_cache:
+      name: "Save tools cache"
+      key: *tools_cache_key
+      paths:
+        - ~/tools
+
+commands:
+  tools-versions:
+    steps:
+      - run:
+          name: Tools Versions
+          command: |
+            java -version
+            bb --version
+  install-babashka-macos-linux:
+    steps:
+      - run:
+          name: Install Babashka
+          # temporarily use SNAPSHOT version, use latest official after next bb bump
+          command: |
+            bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --version 1.3.180-SNAPSHOT --dir .
+            sudo mv ./bb /usr/local/bin/bb
+            bb --version
+  install-babashka-windows:
+    steps:
+      - run:
+          name: Install Babashka
+          # Temporarily using snapshot, switch to scoop after next bb release
+          command: |
+            iwr https://github.com/babashka/babashka-dev-builds/releases/download/v1.3.180-SNAPSHOT/babashka-1.3.180-SNAPSHOT-windows-amd64.zip -outfile 'bbwin.zip'; if(-not $?){exit 9}
+            Expand-Archive bbwin.zip .                                    ; if(-not $?){exit 9}
+            mkdir C:\bbtools                                              ; if(-not $?){exit 9}
+            mv .\bb.exe C:\bbtools                                        ; if(-not $?){exit 9}
+            add-content $PROFILE $("`$env:PATH=""C:\bbtools;`$env:PATH"""); if(-not $?){exit 9}
+            Write-host $env:PATH                                          ; if(-not $?){exit 9}
+
+  setup:
+    parameters:
+      os:
+        type: string
+      jdk:
+        type: string
+    steps:
+      - run:
+          name: "Bundled executor java version"
+          command: java -version
+      - when:
+          condition:
+            not:
+              equal: [ 'windows', <<parameters.os>> ]
+          steps:
+            - install-babashka-macos-linux
+      - when:
+          condition:
+            equal: [ 'windows', <<parameters.os>> ]
+          steps:
+            - install-babashka-windows
+      - run:
+          name: "Setup JDK"
+          command: |
+            bb -ci-install-jdk <<parameters.os>> << parameters.jdk >>
+
 jobs:
-  java-8:
-    docker:
-      # specify the version you desire here
-      - image: circleci/clojure:openjdk-8-lein
-    working_directory: ~/repo
-    environment:
-      LEIN_ROOT: "true"
-    resource_class: large
+  test:
+    parameters:
+      os:
+        type: string
+      jdk:
+        type: string
+    executor:
+      name: << parameters.os >>
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "project.clj" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+      - *restore_deps_cache
+      - *restore_tools_cache
+      - setup:
+          os: << parameters.os >>
+          jdk: << parameters.jdk >>
+      - tools-versions
       - run:
-          name: Install Clojure
+          name: Run bb tests
           command: |
-            wget https://download.clojure.org/install/linux-install-1.10.3.1040.sh
-            chmod +x linux-install-1.10.3.1040.sh
-            sudo ./linux-install-1.10.3.1040.sh
-      - run:
-          name: Install Babashka
-          command: |
-            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
-            bb --version
+            bb test:bb
       - run:
           name: Run JVM tests
           command: |
-            script/test
-  java-11:
-    docker:
-      # specify the version you desire here
-      - image: circleci/clojure:openjdk-11-lein
-    working_directory: ~/repo
-    environment:
-      LEIN_ROOT: "true"
-    resource_class: large
+            bb test:jvm :clj-all
+      - *save_deps_cache
+      - *save_tools_cache
+
+  test-native:
+    parameters:
+      os:
+        type: string
+      jdk:
+        type: string
+    executor:
+      name: << parameters.os >>
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "project.clj" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run:
-          name: Install Clojure
-          command: |
-            wget https://download.clojure.org/install/linux-install-1.10.3.1040.sh
-            chmod +x linux-install-1.10.3.1040.sh
-            sudo ./linux-install-1.10.3.1040.sh
-      - run:
-          name: Install Babashka
-          command: |
-            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
-            bb --version
-      - run:
-          name: Run JVM tests
-          command: |
-            script/test
+      - *restore_deps_cache
+      - *restore_tools_cache
+      - setup:
+          os: << parameters.os >>
+          jdk: << parameters.jdk >>
+      - tools-versions
+      - when:
+          condition:
+            equal: [ 'windows', <<parameters.os>> ]
+          steps:
+            - run:
+                name: "Run native tests (windows)"
+                # setting vcvars.bat in powershell is awkward
+                command: |
+                  cmd.exe /c "call `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat`" && set > %temp%\vcvars.txt"
+                  Get-Content "$env:temp\vcvars.txt" | Foreach-Object {
+                  if ($_ -match "^(.*?)=(.*)$") {
+                    Set-Content "env:\$($matches[1])" $matches[2]
+                    }
+                  }
+                  bb test:native
+      - when:
+          condition:
+            not:
+              equal: [ 'windows', <<parameters.os>> ]
+          steps:
+            - run:
+                name: "Run native tests (linux, macos)"
+                command: |
+                  bb test:native
+      - *save_deps_cache
+      - *save_tools_cache
+
   deploy:
     resource_class: large
     docker:
@@ -73,28 +184,30 @@ jobs:
       LEIN_ROOT: "true"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "project.clj" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      - *restore_deps_cache
       - run: .circleci/script/deploy
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "project.clj" }}
+      - *save_deps_cache
 
 workflows:
   version: 2
   ci:
     jobs:
-      - java-8
-      - java-11
+      - test:
+          name: test-<< matrix.os >>-<< matrix.jdk >>
+          matrix:
+            parameters:
+              os: [linux, macos, windows]
+              jdk: ['temurin@8','temurin@11','temurin@17']
+      - test-native:
+          name: test-<< matrix.os >>-native
+          matrix:
+            parameters:
+              os: [linux, macos, windows]
+              jdk: ['graalvm_ce19']
       - deploy:
           filters:
             branches:
               only: master
           requires:
-            - java-8
-            - java-11
-
+            - test
+            - test-native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         java-version: ["8", "11", "17"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu, macOS, windows]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    name: test-${{ matrix.os }}-temurin@${{ matrix.java-version }}
 
     steps:
     - name: "Checkout code"
@@ -31,18 +32,78 @@ jobs:
           ~/.deps.clj
         key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn','bb.edn') }}"
 
-    - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@10.3
+    # Temporary, switch to installing from setup-clojure action after next bb released
+    - name: Setup Babashka Snapshot (macos,linux)
+      if: runner.os != 'windows'
+      run: |
+        bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --version 1.3.180-SNAPSHOT --dir .
+        sudo mv ./bb /usr/local/bin/bb
+
+    # Temporary, switch to installing from setup-clojure action after new bb released
+    # No handy installer for Windows, so diy
+    - name: Setup Babashka Snapshot (windows)
+      if: runner.os == 'windows'
+      run: |
+        C:\msys64\usr\bin\wget.exe -nv -O bbwin.zip https://github.com/babashka/babashka-dev-builds/releases/download/v1.3.180-SNAPSHOT/babashka-1.3.180-SNAPSHOT-windows-amd64.zip
+        Expand-Archive bbwin.zip .
+        mkdir C:\bbtools
+        mv .\bb.exe C:\bbtools
+        echo "C:\bbtools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Tools Versions
+      run: |
+        java -version
+        bb --version
+
+    - name: Run bb tests
+      run: |
+        bb test:bb
+
+    - name: Run JVM tests
+      run: |
+        bb test:jvm :clj-all
+
+  test-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macOS, windows]
+
+    runs-on: ${{ matrix.os }}-latest
+    name: test-${{ matrix.os }}-native
+
+    steps:
+    - name: "Checkout code"
+      uses: "actions/checkout@v3"
+
+    - name: Install GraalVM
+      uses: graalvm/setup-graalvm@v1
       with:
-        cli: 1.10.3.1040
+        # match version babashka uses
+        version: '22.3.1'
+        java-version: 19
+        components: 'native-image'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Restore Cache"
+      uses: "actions/cache@v3"
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.deps.clj
+        key: "${{ runner.os }}-deps-${{ hashFiles('deps.edn','bb.edn') }}"
+
+    - name: Setup Babashka
+      uses: DeLaGuardo/setup-clojure@10.1
+      with:
         bb: 'latest'
 
-    - name: Download bb deps
-      run:
+    - name: Tools Versions
+      run: |
+        java -version
         bb --version
 
     - name: Run tests
       run: |
-        clojure -M:clj-1.9:test
-        clojure -M:clj-1.10:test
-        clojure -M:clj-1.11:test
+        bb test:native

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .clj-kondo/.cache
 .lein-failures
 /target
+/test-native/target
 pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 [Babashka process](https://github.com/babashka/process)
 Clojure library for shelling out / spawning sub-processes
 
+## Unreleased
+
+- [#123](https://github.com/babashka/process/issues/123): `exec` now converts `:env` and `:extra-env` keywords ([@lread](https://github.com/lread))
+
 ## 0.5.21 (2023-05-18)
 
 - [#126](https://github.com/babashka/process/issues/126): Consider `:dir` when resolving relative `program` on Windows ([@lread](https://github.com/lread))

--- a/bb.edn
+++ b/bb.edn
@@ -1,14 +1,80 @@
-{:deps {io.github.borkdude/quickdoc
+{:paths ["script"]
+ :deps {io.github.borkdude/quickdoc
         #_{:local/root "../../quickdoc"}
         {:git/url "https://github.com/borkdude/quickdoc"
-         :git/sha "32e726cd6d785d00e49d4e614a05f7436d3831c0"}}
-
+         :git/sha "32e726cd6d785d00e49d4e614a05f7436d3831c0"}
+        org.clj-commons/digest {:mvn/version "1.4.100"} }
  :tasks
- {quickdoc {:doc "Invoke quickdoc"
+ {:requires ([babashka.fs :as fs])
+  clean {:doc "Delete build work"
+         :task (do
+                 (fs/delete-tree "target")
+                 (shell {:dir "test-native"} "bb clean"))}
+  quickdoc {:doc "Invoke quickdoc"
             :requires ([quickdoc.api :as api])
             :task (api/quickdoc {:git/branch "master"
                                  :github/repo "https://github.com/babashka/process"
                                  :toc true
                                  :var-links true})}
-  test {:doc "Run tests"
-        :task (shell "script/test")}}}
+
+  -prep-native-exec {:doc "Prep for native exec test"
+                     :task (shell {:dir "test-native"} "bb native")}
+
+  test:native {:doc "Run exec tests with native runner (requires GraalVM compilation)."
+               :depends [-prep-native-exec]
+               :task (apply clojure "-M:test:clj-1.11" "--namespace" "babashka.process-exec-test" *command-line-args*)}
+
+  test:bb {:doc "Run all tests under bb"
+           :extra-paths ["test"]
+           :extra-deps  {;; inherit base deps from deps.edn
+                         babashka/process {:local/root "."}
+                         ;; repeat necessary :test deps from deps.edn
+                         io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :requires ([cognitect.test-runner])
+           :task (do
+                   ;; flag: sub-process should reload babashka.process
+                   (System/setProperty "babashka.process.test.reload" "true")
+                   ;; flag: force use of bb even if natively compiled version of run-exec exists
+                   (System/setProperty "babashka.process.test.run-exec" "bb")
+                   ;; run from babashka.process sources, not built-in babaska.process
+                   (require '[babashka.process] :reload)
+                   (apply cognitect.test-runner.-main *command-line-args*))}
+
+  test:jvm {:doc "Run jvm tests, optionally specify clj-version (ex. :clj-1.10 :clj-1.11(default) or :clj-all)"
+            :requires ([clojure.string :as str]
+                       [clojure.edn :as edn])
+            :task (let [args *command-line-args*
+                        farg (first *command-line-args*)
+                        ;; allow for missing leading colon
+                        farg (if (str/starts-with? farg "clj-")
+                               (str ":" farg)
+                               farg)
+                        clj-version-aliases (->> "deps.edn"
+                                                 slurp
+                                                 edn/read-string
+                                                 :aliases
+                                                 keys
+                                                 (map str)
+                                                 (filter (fn [a] (-> a name (str/starts-with?  ":clj-"))))
+                                                 (into []))
+                        [aliases args] (cond
+                                         (nil? farg) [[":clj-1.11"] []]
+
+                                         (= ":clj-all" farg) [clj-version-aliases (rest args)]
+
+                                         (and (str/starts-with? farg ":clj-")
+                                              (not (some #{farg} clj-version-aliases)))
+                                         (throw (ex-info (format "%s not recognized, valid clj- args are: %s or \":clj-all\"" farg clj-version-aliases) {}))
+
+                                         (some #{farg} clj-version-aliases) [[farg] (rest args)]
+
+                                         :else [[":clj-1.11"] args])]
+                    (doseq [alias aliases]
+                      (do
+                        (println (format "-[Running jvm tests for %s]-" alias))
+                        (apply clojure (str "-M:test" alias) "--namespace" "babashka.process-test" args))))}
+
+  ;; hidden CI support tasks
+  -ci-install-jdk {:doc "Helper to download and install jdk under ~/tools on circleci"
+                   :requires ([circle-ci])
+                   :task (apply circle-ci/install-jdk *command-line-args*)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,6 @@
 {:deps {babashka/fs {:mvn/version "0.4.18"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {cognitect/test-runner
-                               {:git/url "https://github.com/cognitect-labs/test-runner"
-                                :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
+                  :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :main-opts ["-m" "cognitect.test-runner"]}
            :clj-1.9 {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
            :clj-1.10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,4 +1,5 @@
 {:cljdoc.doc/tree
  [["Readme" {:file "README.md"}]
-  ["Changelog" {:file "CHANGELOG.md"}]]
+  ["Changelog" {:file "CHANGELOG.md"}]
+  ["Developer Documentation" {:file "doc/dev.md"}]]
  :cljdoc/languages ["clj"]}

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -1,0 +1,49 @@
+# Developer Documentation
+
+Use bb tasks to run tests, run `bb tasks` to see what is available.
+
+Test tasks all support cognitect test runner command line args, so you can for example:
+
+```Shell
+$ bb test:bb --var "babashka.process-test/tokenize-test"
+```
+
+## JVM Tests
+The `test:jvm` task checks the first arg. If it starts with `:clj-`, it is assumed to be a
+`deps.edn` alias used to select the Clojure version. Use `:clj-all` to repeat tests for all
+`:clj-*` aliases. Default is the current version of Clojure.
+
+Because `exec` requires native compilation, these JVM tests do not run
+`babashka.process-exec-test`.
+
+Testing default Clojure version:
+```Shell
+$ bb test:jvm
+```
+
+Testing under Clojure 1.9:
+```Shell
+$ bb test:jvm :clj-1.9
+```
+
+Testing all supported Clojure versions:
+```Shell
+$ bb test:jvm :clj-all
+```
+
+## Native/bb tests 
+The `babashka.process/exec` can only be run when natively compiled by GraalVM native-image.
+See `babashka.process-exec-test` namespace for some details.
+
+Exec tests are supported by `run_exec.clj` which can be found under `~/test-native`.
+
+The `test:native` task natively compiles `run_exec.clj` and exercises it through 
+`babashka.process-exec-test`s. AOT compilation and native-image creation are not
+repeated unless they seem stale. To force a full recompile, run `bb clean` before 
+`bb test:native`.
+
+The `test:bb` task runs all babashka.process tests. It runs `run_exec.clj` through bb.
+The `run_exec.clj` code will reload the `babashka.process` namespace when the 
+`babashka.process.test.reload` system property is set. A reload of `babashka.process` 
+switches from the `babashka.process` that is built-in to bb to using `babashka.process` 
+from sources.

--- a/script/circle_ci.clj
+++ b/script/circle_ci.clj
@@ -1,0 +1,144 @@
+(ns circle-ci
+  (:require [babashka.http-client :as http]
+            [babashka.fs :as fs]
+            [babashka.tasks :as t]
+            [cheshire.core :as json]
+            [clj-commons.digest :as digest]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(defn- tools-dir[]
+  (let [home-dir (System/getProperty "user.home")]
+    (str (fs/file home-dir "tools"))))
+
+(defn- jdk-info
+  "Use disco API to find our jdk"
+  [{:keys [os jdk-major distro archive-type]}]
+  (let [packages (-> (http/get "https://api.foojay.io/disco/v3.0/packages"
+                               {:query-params {"distro" distro
+                                               "package_type" "jdk"
+                                               "latest" "available"
+                                               "jdk_version" jdk-major
+                                               "operating_system" os
+                                               "architecture" "x64"
+                                               "archive_type" archive-type}})
+                     :body
+                     (json/parse-string true)
+                     :result)
+        ;; seems temurin alpine release is classified under linux os rather than alpine_linux os
+        ;; we are not interested in the alpine release
+        packages (remove #(str/includes? (:filename %) "alpine") packages)]
+    (when (not= 1 (count packages))
+      (throw (ex-info (format "Expected 1 package to match, got: %s" (pr-str packages)) {})))
+    (let [package (first packages)
+          download-info (-> package
+                            :links
+                            :pkg_info_uri
+                            http/get
+                            :body
+                            (json/parse-string true)
+                            :result
+                            first)]
+      (merge package download-info))))
+
+(defn- set-jdk-env [os install-dir]
+  (let [jdk-dir (->> install-dir fs/list-dir (filter fs/directory?) first str)
+        java-home (if (= "macos" os)
+                    (str (fs/file jdk-dir "Contents/home"))
+                    jdk-dir)
+        java-bin (str (fs/file java-home "bin"))
+        on-ci (System/getenv "CI")
+        graal (str/includes? install-dir "graal")]
+    (println "Setting up JAVA_HOME to" java-home)
+    (let [dest-file (cond
+                      (not on-ci) "<NOT-WRITTEN, NOT ON CI>"
+                      ;; $PROFILE is not an environment variable, it must be fetched from powershell
+                      (= "windows" os) (-> (t/shell {:out :string}
+                                                    "powershell.exe -Command $PROFILE")
+                                           :out str/trim)
+                      :else (System/getenv "BASH_ENV"))
+          env-entries (if (= "windows" os)
+                        (cond-> [(format "$env:JAVA_HOME=\"%s\"" java-home)
+                                 (format "$env:PATH=\"%s;$env:PATH\"" java-bin)]
+                          ;; not really necessary but some like to set it
+                          graal (conj (format "$env:GRAALVM_HOME=\"%s\"" java-home)))
+                        (cond-> [(format "export JAVA_HOME=\"%s\"" java-home)
+                                 (format "export PATH=\"%s:$PATH\"" java-bin)]
+                          ;; not really necessary but some like to set it
+                          graal (conj (format "export GRAALVM_HOME=\"%s\"" java-home))))]
+      (println "writing to:" dest-file)
+      (doseq [p env-entries]
+        (do
+          (println p) ;; nice for debugging locally and on circleci
+          (when on-ci
+            (spit dest-file (format "%s\n" p) :append true)))) )))
+
+(defn- parse-jdk
+  "Disco distro for graal includes the major.jdk ex graalvm_ce19, so we don't have client respecify it."
+  [s]
+  (or (some-> (re-find #"(graalvm_ce)(.+)" s) ((juxt first last)))
+      (some-> (re-find #"(.+)@(.+)" s) rest)))
+
+(defn- verify-checksum [download-file checksum_type checksum_uri]
+  (println "Verifying sha")
+  (when (not= "sha256" checksum_type)
+    (throw (ex-info (format "Not handling checkum_type %s yet" checksum_type) {})))
+  (let [expected-sha256 (-> (http/get checksum_uri)
+                            :body
+                            (str/split #" ") ;; ignore filename if present
+                            first)
+        actual-sha256 (digest/sha-256 (fs/file download-file))]
+    (when (not= expected-sha256 actual-sha256)
+      (throw (ex-info (format "Expected sha %s != actual %s" expected-sha256 actual-sha256) {})))))
+
+;; bb task entry points
+(defn install-jdk [& args]
+  (let [[os distro-jdk-major] args
+        [distro jdk-major] (parse-jdk distro-jdk-major)
+        tools-dir (tools-dir)
+        ext (if (= "windows" os) "zip" "tar.gz")
+        {:keys [direct_download_uri
+                checksum_uri
+                checksum_type
+                java_version]} (jdk-info {:os os
+                                          :distro distro
+                                          :jdk-major jdk-major
+                                          :archive-type ext})
+        install-dir (str (fs/file tools-dir (format "%s-%s" distro java_version)))
+        download-file (str (fs/file install-dir (format "%s.%s" distro ext)))]
+    (println "Installing" distro jdk-major)
+    ;; allow for caching
+    (if (fs/exists? install-dir)
+      (println "Already installed to" install-dir)
+      (try (println "Downloading" direct_download_uri)
+           (fs/create-dirs install-dir)
+           (io/copy
+            (:body (http/get direct_download_uri {:as :stream}))
+            (io/file download-file))
+           (verify-checksum download-file checksum_type checksum_uri)
+           (println "Unpacking download to" install-dir)
+           (if (= "zip" ext)
+             (fs/unzip download-file install-dir)
+             (t/shell {:dir install-dir} "tar xzf" download-file))
+           (fs/delete download-file)
+           (catch Throwable ex
+             (when (fs/exists? install-dir)
+               (fs/delete-tree install-dir))
+             (throw ex))))
+    (set-jdk-env os install-dir)))
+
+(comment
+  (install-jdk "macos" "temurin@11")
+  (install-jdk "windows" "temurin@17")
+  (install-jdk "linux" "temurin@11")
+  (install-jdk "linux" "graalvm_ce19")
+  (install-jdk "windows" "graalvm_ce19")
+
+  (install-jdk "linux" "temurin@8")
+
+  (parse-jdk "graalvm_ce19")
+  ;; => ["graalvm_ce19" "19"]
+
+  (parse-jdk "foo@123")
+  ;; => ("foo" "123")
+)

--- a/script/test
+++ b/script/test
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-clojure -M:test @$

--- a/script/wd.clj
+++ b/script/wd.clj
@@ -1,6 +1,7 @@
 ;; wd - wee dummy - an os-agnostic bb script launched by our unit tests
 (require '[clojure.java.io :as io]
-         '[clojure.string :as str])
+         '[clojure.java.shell :as shell]
+         '[clojure.string :as str] )
 
 ;; usage
 ;; :out <somestring> - dump <somestring> to stdout
@@ -9,6 +10,8 @@
 ;; :env - dump env to stdout
 ;; :grep <somestring> - returns all lines from stdin matching <somestring>
 ;; :upper - read and emit lines from stdin, but converted to uppercase
+;; :ps-me - dump some info for current process (macOS & Linux only)
+;; :sleep <ms> - sleep for <ms>
 ;; :exit <someval> - exits with <someval>
 
 ;; the naivest of cmd line parsing
@@ -22,6 +25,9 @@
               (println l))
     ":upper" (doseq [l (->> *in* io/reader line-seq)]
                (println (str/upper-case l)))
+    ;; macos and linux only
+    ":ps-me" (let [pid (.pid (java.lang.ProcessHandle/current))]
+               (pr {:args (-> (shell/sh "ps" "-o" "args=" (str pid)) :out str/trim)}))
     ":sleep" (Thread/sleep (parse-long val))
     ":exit" (System/exit (parse-long val))
     nil))

--- a/test-native/bb.edn
+++ b/test-native/bb.edn
@@ -1,0 +1,70 @@
+{:deps {;; delete after bb bumps fs
+        babashka/fs {:mvn/version "0.4.18"}}
+ :tasks
+ {:requires ([babashka.fs :as fs] :reload ;; remove :reload after bb bumps fs
+             [clojure.string :as str])
+
+  clean {:doc "Clean"
+         :task (doseq [d ["target" ".cpcache"]]
+                 (fs/delete-tree d))}
+
+  aot {:doc "AOT Compile Clojure"
+       :task (let [target "target/classes"
+                   newer-thans (fs/modified-since "target/classes"
+                                                  ["src" "../src"])]
+               (if (not (seq newer-thans))
+                 (println (format "Skipping AOT compilation, sources already compiled to %s." target))
+                 (do
+                   (println "AOT Compiling Clojure sources")
+                   (fs/delete-tree ".cpcache")
+                   (fs/delete-tree target)
+                   (fs/create-dirs target)
+                   (clojure "-M" "-e"
+                            (format "(binding [*compile-path* \"%s\"] (compile 'babashka.test-native.run-exec))"
+                                    target)))))}
+
+
+  -graalvm-native-image-exe
+  {:doc "Installs/resolves and returns graalvm native-image binary"
+   :task (when-let [native-image (if-let [ghome (System/getenv "GRAALVM_HOME")]
+                                   (or (fs/which (fs/file ghome "bin" "native-image"))
+                                       (if-let [gu (fs/which (fs/file ghome "bin" "gu"))]
+                                         (do
+                                           (shell gu "install" "native-image")
+                                           (fs/which (fs/file ghome "bin" "native-image")))
+                                         (throw (ex-info "Could not find GraalVM gu via GRAALVM_HOME." {}))))
+                                   (or (fs/which "native-image")
+                                       (if-let [gu (fs/which "gu")]
+                                         (do (shell gu "install" "native-image")
+                                             (fs/which "native-image"))
+                                         (throw (ex-info "GRAALVM_HOME not set, and did not find GraalVM gu on PATH" {})))))]
+           (println "Using GraalVM native-image:" (str native-image))
+           (shell native-image "--version")
+           native-image)}
+
+  -exe-name {:doc "Returns executable name to be built"
+             :task (do
+                     (load-file "../test/babashka/process/test_utils.clj")
+                     (deref (requiring-resolve 'babashka.process.test-utils/run-exec-exe)))}
+
+  native {:doc "Compile AOT to native image"
+          :depends [aot -exe-name]
+          :task (let [exe-dir "target"
+                      exe-file (fs/which (fs/file exe-dir -exe-name))
+                      newer-thans (fs/modified-since exe-file
+                                                     "target/classes")]
+                  (if (not (seq newer-thans))
+                    (println (format "Skipping native-image creation, AOT already compiled to %s." exe-file))
+                    (let [classpath (-> (clojure "-Spath")
+                                        with-out-str
+                                        str/trim)]
+                      (println "Creating native image")
+                      (let [native-image (run '-graalvm-native-image-exe)]
+                        (shell
+                         native-image
+                         "-cp" (str classpath (System/getProperty "path.separator") "target/classes")
+                         (str "-H:Path=" exe-dir)
+                         (str "-H:Name=" -exe-name)
+                         "--verbose"
+                         "--no-fallback"
+                         "babashka.test_native.run_exec")))))}}}

--- a/test-native/deps.edn
+++ b/test-native/deps.edn
@@ -1,0 +1,9 @@
+{:deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        babashka/process {:local/root ".."}
+        com.github.clj-easy/graal-build-time {:mvn/version "0.1.4"}}
+ :aliases
+ {:test ;; added by neil
+  {:extra-paths ["test"]
+   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn cognitect.test-runner.api/test}}}

--- a/test-native/src/babashka/test_native/bb.edn
+++ b/test-native/src/babashka/test_native/bb.edn
@@ -1,0 +1,2 @@
+;; when run from bb we want to be able to load our local sources
+{:paths ["../../../../src"]}

--- a/test-native/src/babashka/test_native/run_exec.clj
+++ b/test-native/src/babashka/test_native/run_exec.clj
@@ -1,0 +1,66 @@
+;; a wee script to test exec
+;; exec can only run when natively compiled by GraalVM so this script must be run from bb
+;; or from a custom natively compile app
+(ns babashka.test-native.run-exec
+  (:require [clojure.edn :as edn]
+            [clojure.walk :as walk])
+  (:gen-class))
+
+;; When running from bb, if we wish to use babashka.process from sources
+;; rather than the babashka.process that has been compiled into the bb
+;; binary, we must reload the babasha.process namespace
+(if (and (System/getProperty "babashka.version") ;; running from bb?
+         (System/getProperty "babashka.process.test.reload")) ;; set by our tests
+  (require '[babashka.process :as p] :reload)
+  (require '[babashka.process :as p]))
+
+(set! *warn-on-reflection* true)
+
+(defn- load-exec-args
+  "Load args for exec from edn.
+  To keep things simple, we'll replace any specified :pre-start-fn with a canned one. "
+  [args]
+  (->> args
+       edn/read-string
+       (walk/postwalk (fn [n]
+                        (if (:pre-start-fn n)
+                          (assoc n :pre-start-fn (fn [m] (println "Pre-start-fn output" m)))
+                          n)))))
+
+(defn- parse-args [args]
+  (cond
+    (= 1 (count args))
+    (load-exec-args (first args))
+
+    (and (= 2 (count args))
+         (or (= "--file" (first args))
+             (= "-f" (first args))))
+    (-> (second args) slurp load-exec-args)
+
+    :else
+    (throw (ex-info "Invalid usage, specify '(some list of args for exec)' or --file args-in.edn" {}))))
+
+
+(defn -main
+  "call with a list of `args` for `babashka.process/exec`
+
+  for adhoc (under bash, Windows shell will have different escaping rules):
+  bb exec-run.clj \"({:arg0 'new-arg0'} bb wd.clj :out foo :exit 3)\"
+
+  to avoid shell command escaping hell can also read args from edn file
+  bb exec-run.clj --file some/path/here.edn"
+  [& args]
+  (let [exec-args (parse-args args)]
+    (try
+      #_{:clj-kondo/ignore [:unresolved-namespace]}
+      (apply p/exec exec-args)
+      ;; we should never reach this line
+      (println "ERROR: exec did not replace process.")
+      (System/exit 42)
+      (catch Exception ex
+        ;; an error occurred launching exec
+        (println (pr-str (Throwable->map ex)))))))
+
+;; support invocation from babashka when run as script
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/test/babashka/process/test_utils.clj
+++ b/test/babashka/process/test_utils.clj
@@ -1,0 +1,68 @@
+(ns babashka.process.test-utils
+  "Common test utilitities used by not only our tests but also bb build scripting."
+  (:require  [babashka.fs :as fs]
+             [clojure.java.shell :as shell]
+             [clojure.string :as str]))
+
+(defn *find-bb
+  "Find bb on current directory else on path.
+  Return unresolved bb, it is the job of babashka process, at least on Windows to resolve the exe."
+  []
+  (or (and (fs/which "./bb") "./bb")
+      (and (fs/which "bb") "bb")))
+
+(def os
+  "Sometimes we need to know if we are running on macOS, in those cases fs/windows? does not cut it"
+  (condp re-find (str/lower-case (System/getProperty "os.name"))
+    #"win" :win
+    #"mac" :mac
+    #"(nix|nux|aix)" :linux ;; calling unix variants linux because that is more likely the case
+    #"sunos" :solaris
+    :unknown))
+
+(def run-exec-exe
+  "Including the os name in the run-exec exe is helpful to devs using shared folders on multiple OSes.
+  On windows exe name is naturally distinguished, but on macOS and Linux it is not."
+  (str (name os) "-run-exec"))
+
+(defn always-present-env-vars
+  "Even when requesting an empty environment, some OSes do not return an empty environment"
+  []
+  (os {:mac ["__CF_USER_TEXT_ENCODING"]
+       :win ["SystemRoot"]}))
+
+(defn print-test-env[]
+  (let [bb (*find-bb)]
+    (println "- calling babashka as:" (if bb (str bb) "<not found>"))
+    (when bb
+      (println (format "  - which resolves to: %s" (-> (fs/which bb) fs/canonicalize)))
+      (println (format "  - %s" (-> (shell/sh (-> (fs/which bb) str) "--version") :out str/trim))))))
+
+(def wd
+  "Wee dummy script location. Understands that these tests are run from babashka/process or babashka."
+  (->> ["process/script/wd.clj"
+        "script/wd.clj"]
+       (filter fs/exists?)
+       first))
+
+(defn ols
+  "Return s with line separators converted for current operating system"
+  [s]
+  (str/replace s "\n" (System/getProperty "line.separator")))
+
+(defn find-bb
+  "Tests launch an os-agnostic bb script that emits/behaves in ways useful
+  to exercising babashka.process. Any test that uses bb should find it via
+  this function.
+
+  Babashka proper also runs these tests under the jvm and native-image.
+  For babashka proper jvm tests, bb does not exist in the CI environment.
+  This function allows jvm tests to be skipped without error in this scenario.
+  This is fine because jvm tests are simply a pre-cursor/quick-way to run tests
+  before they are repeated for native-image where any test failures will ultimately
+  be caught."
+  []
+  (or (*find-bb)
+      (if (= "jvm" (System/getenv "BABASHKA_TEST_ENV"))
+        (println "WARNING: Skipping test because bb not found in path or current dir.")
+        (throw (ex-info "ERROR: bb not found in path or current dir" {})))))

--- a/test/babashka/process_exec_test.clj
+++ b/test/babashka/process_exec_test.clj
@@ -1,0 +1,185 @@
+(ns babashka.process-exec-test
+  "The `babashka.process/exec` fn can only be run from a GraalVM natively
+  compiled executable. We have separated exec tests to this namespace
+  so that can be easily included/execluded from a test run.
+
+  Because `exec` replaces the existing process, we need to launch an exec
+  runner that will be replaced. (We don't want our test runner to replaced).
+  Our exec runner source is `test-native/src/babashka/test_native/run_exec.clj`.
+
+  Our exec runner will typically in turn launch our wee dummy script `wd.clj`.
+
+  Various ways which these tests are run:
+  - from babashka.process
+    - `test:native` task - tests against natively compiled `run_exec.clj`
+       (and in turn a natively compiled babashka.process)
+    - `test:bb` task - tests under bb using `run_exec.clj` from source against
+      `babashka.process` from source
+  - from babashka lib tests
+    - `BABASHKA_TEST_ENV` is `jvm` - tests are skipped
+    - `BABASHKA_TEST_ENV` is not `jvm` (presumably `native`) - tests are run under bb twice both using
+      `run-exec.clj` from source:
+      - once against natively compiled babashka.process within bb
+      - a second time against babashka.process from source
+
+  Note that we launch our exec runner via `clojure.java.shell/sh` to avoid using `babashka.proccess`
+  which is under test."
+  (:require [babashka.fs :as fs]
+            [babashka.process.test-utils :as u]
+            [clojure.edn :as edn]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]))
+
+(defn- find-exec-runner
+  "Returns program arg vector for test runner.
+
+  Depending on the test scenario, we'll either use our natively compiled `run_exec.clj`
+  or we'll use `bb` to run `run_exec.clj` from source.
+  See namespace docs for details."
+  []
+  (or (and (not= "bb" (System/getProperty "babashka.process.test.run-exec"))
+           (some-> (fs/which (fs/file "./test-native/target" u/run-exec-exe))
+                   fs/canonicalize
+                   str
+                   vector))
+      (when-let [bb (u/*find-bb)]
+        [(-> (fs/which bb) fs/canonicalize str)
+         (->> ["process/test-native/src/babashka/test_native/run_exec.clj"
+               "test-native/src/babashka/test_native/run_exec.clj"]
+              (filter fs/exists?)
+              first)])))
+
+(defn print-env [f]
+  (u/print-test-env)
+  (println "- using exec runner:" (or (some-> (find-exec-runner) str) "<not found>"))
+  (f))
+
+(use-fixtures :once print-env)
+
+(def ^:private exec-runner (find-exec-runner))
+
+(defn- run-exec
+  "Launch process that will exercise `babasha.process/exec`.
+
+  See namespace docs for details.
+
+  When running from bb we control version of babashka.process used via
+  `babashka.process.test.reload` java system property.
+  - if set, work from babashka.process sources
+  - else we'll use the natively compiled built-in babasha.process
+
+  To avoid dealing with any shell escaping rules, we spit `exec-args` to a file
+  for consumption by `run_exec.clj`."
+  [& exec-args]
+  (fs/create-dirs "target")
+  (let [exec-args-file (-> (fs/create-temp-file {:path "target" :prefix "bbp-run-exec" :suffix ".edn"})
+                           fs/absolutize
+                           str)
+        reload-prop "babashka.process.test.reload"
+        svm-opts (when-let [reload-val (System/getProperty reload-prop)]
+                   [(format "-D%s=%s" reload-prop reload-val)])]
+    (fs/delete-on-exit exec-args-file)
+    (spit exec-args-file (pr-str exec-args))
+    (-> (apply shell/sh (concat exec-runner svm-opts ["--file" exec-args-file]))
+        (select-keys [:out :err :exit]))))
+
+(deftest exec-replaces-runner-that-launches-it-test
+  ;; runner prints ERROR:... and returns 42 if not replaced
+  (when-let [bb (u/find-bb)]
+    (is (= {:out (u/ols "hello\n")
+            :err (u/ols "noprobs\n")
+            :exit 100}
+           (run-exec (format "%s %s :err noprobs :out hello :exit 100" bb u/wd))))))
+
+(deftest exec-failure-to-launch-throws-an-exception-test
+  ;; runner dumps serialized exeption on failure to launch
+  (is (= "Path wontfindme does not point to executable file"
+         (-> (run-exec "wontfindme")
+             :out
+             edn/read-string
+             :cause))))
+
+(when (fs/windows?)
+  (deftest arg0-test-windows
+    (when-let [bb (u/find-bb)]
+      (testing "on Windows, arg0 is a no-op, make sure cmd still runs with it"
+        (is (= {:out (u/ols "all good\n")
+                :err ""
+                :exit 0}
+               (run-exec {:arg0 "newarg0"} (format "%s %s :out 'all good'" bb u/wd)))))) ))
+
+(when (not (fs/windows?))
+  (deftest arg0-test-mac-and-linux
+    (when-let [bb (u/find-bb)]
+      (testing "on macOS and Linux, arg0 is supported"
+        (testing "baseline - not overriden"
+          (is (= {:args (format "%s %s :ps-me" bb u/wd)}
+                 (-> (run-exec  (format "%s %s :ps-me" bb u/wd))
+                     :out
+                     edn/read-string))))
+        (is (= {:args (format "newarg0 %s :ps-me" u/wd)}
+               (-> (run-exec {:arg0 "newarg0"} (format "%s %s :ps-me" bb u/wd))
+                   :out
+                   edn/read-string)))))))
+
+(deftest exec-env-option-test
+  (when-let [bb (u/find-bb)]
+    (testing "env is inherited by default"
+      (is (= (->> (System/getenv) (into {}))
+             (-> (run-exec (format "%s %s :env" bb u/wd))
+                 :out
+                 edn/read-string))))
+    (testing "request empty env"
+      (let [vars (-> (run-exec {:env {}}
+                               ;; add -cp '' so that bb does not require JAVA_HOME
+                               (format "%s -cp '' %s :env" bb u/wd))
+                     :out
+                     edn/read-string)
+            expected-vars (u/always-present-env-vars)]
+        (is (= expected-vars (keys vars)))))
+    (testing "add to existing env"
+      (is (= (-> (into {} (System/getenv)) (assoc "FOO" "BAR"))
+             (-> (run-exec {:extra-env {"FOO" "BAR"}}
+                           (format "%s %s :env" bb u/wd))
+                 :out
+                 edn/read-string))))
+    (testing "request a specific env"
+      (let [vars (-> (run-exec {:env {"SOME_VAR" "SOME_VAL"
+                                      :keyword_var "KWVARVAL"
+                                      "keyword_val" :keyword-val}}
+                               ;; add -cp '' so that bb does not require JAVA_HOME
+                               (format "%s -cp '' %s :env" bb u/wd))
+                     :out
+                     edn/read-string)
+            added-vars (apply dissoc vars (u/always-present-env-vars))]
+        (is (= {"SOME_VAR" "SOME_VAL"
+                "keyword_val" ":keyword-val"
+                "keyword_var" "KWVARVAL"}
+               added-vars))))))
+
+(deftest pre-start-fn-test
+  ;; shows that pre-start-fn is active and that executable is resolved
+  (when-let [bb (u/find-bb)]
+    (is (= {:out (u/ols (format "Pre-start-fn output {:cmd [%s %s :out foobar]}\nfoobar\n" (fs/which bb) u/wd))
+            :err ""
+            :exit 0 }
+           ;; runner will always used a canned pre-start-fn, this should excercise the feature
+           ;; this avoids introducing sci for our natively compiled runner
+           (run-exec {:pre-start-fn :canned}
+                     (format "%s %s :out foobar" bb u/wd))))))
+
+(deftest resolves-program
+  ;; use java -version instead of --version, it is supported even on jdk8
+  (let [expected (shell/sh "java" "-version")]
+    (is (zero? (:exit expected)) "sanity expected exit")
+    (is (str/blank? (:out expected)) "sanity expected out" )
+    (is (re-find #"(?i)jdk" (:err expected)) "sanity expected err")
+    (testing "on-path"
+      (is (= expected (run-exec "java -version"))))
+    (testing "absolute"
+      (is (= expected (run-exec (format "'%s' -version" (fs/canonicalize (fs/which "java")))))))
+    (testing "relative"
+      (let [java-dir (-> (fs/which "java") fs/parent fs/absolutize str)]
+        (shell/with-sh-dir java-dir
+          (= expected (run-exec "./java -version")))))))

--- a/test/babashka/process_test.cljc
+++ b/test/babashka/process_test.cljc
@@ -1,49 +1,19 @@
 (ns babashka.process-test
   (:require [babashka.fs :as fs]
             [babashka.process :refer [tokenize process check sh $ pb start] :as p]
+            [babashka.process.test-utils :as u]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
-            [clojure.test :as t :refer [deftest is testing]]))
+            [clojure.test :as t :refer [deftest is testing use-fixtures]]))
 
-(defn- *find-bb
-  "Find bb on path else in current directory.
-  Return unresolved bb, it is the job of babashka process, at least on Windows to resolve the exe."
-  []
-  (or (and (fs/which "bb") "bb")
-      (and (fs/which "./bb") "./bb")))
+(defn print-env [f]
+  (u/print-test-env)
+  (println "- testing clojure version:" (clojure-version))
+  (f))
 
-(println "Testing clojure version:" (clojure-version))
-(println "Calling babashka as:" (if-let [bb (*find-bb)]
-                                  (format "%s (resolves to: %s)" bb (fs/which bb))
-                                  "<not found>"))
-
-(def ^:private wd
-  "Wee dummy script location. Understands that these tests are run from babashka/process or babashka."
-  (->> ["process/script/wd.clj"
-        "script/wd.clj"]
-       (filter fs/exists?)
-       first))
-
-(def ^:private os
-  "Sometimes we need to know if we are running on macOS, in those cases fs/windows? does not cut it"
-  (condp re-find (str/lower-case (System/getProperty "os.name"))
-    #"win" :win
-    #"mac" :mac
-    #"(nix|nux|aix)" :unix
-    #"sunos" :solaris
-    :unknown))
-
-(def ^:private always-present-env-vars
-  "Even when requesting an empty environment, some OSes do not return an empty environment"
-  {:mac ["__CF_USER_TEXT_ENCODING"]
-   :win ["SystemRoot"]})
-
-(defn- ols
-  "Return s with line separators converted for current operating system"
-  [s]
-  (str/replace s "\n" (System/getProperty "line.separator")))
+(use-fixtures :once print-env)
 
 (defn- resolve-exe
   "For the purposes of these tests, we sometimes need to expect how babashka process will resolve an exe for :cmd."
@@ -51,23 +21,6 @@
   (if (fs/windows?)
     (-> exe fs/which str)
     exe))
-
-(defn- find-bb
-  "Tests launch an os-agnostic bb script that emits/behaves in ways useful
-  to exercising babashka.process. Any test that uses bb should find it via
-  this function.
-
-  Babashka proper also runs these tests under the jvm and native-image.
-  For babashka proper jvm tests, bb does not exist in the CI environment.
-  This function allows jvm tests to be skipped without error in this scenario.
-  This is fine because jvm tests are simply a pre-cursor/quick-way to run tests
-  before they are repeated for native-image where any test failures will ultimately
-  be caught."
-  []
-  (or (*find-bb)
-      (if (= "jvm" (System/getenv "BABASHKA_TEST_ENV"))
-        (println "WARNING: Skipping test because bb not found in path or current dir.")
-        (throw (ex-info "ERROR: bb not found in path or current dir" {})))))
 
 (deftest tokenize-test
   (is (= [] (tokenize "")))
@@ -96,18 +49,18 @@
 #?(:bb nil
    :clj
    (deftest parse-args-test
-     (when-let [bb (find-bb)]
-       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb wd)) "cat"])]
+     (when-let [bb (u/find-bb)]
+       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb u/wd)) "cat"])]
          (is (instance? babashka.process.Process (:prev norm)))
          (is (= ["cat"] (:cmd norm))))
-       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb wd))
+       (let [norm (p/parse-args [(p/process (format "%s %s :out hello" bb u/wd))
                                  ["cat"] {:out :string}])]
          (is (instance? babashka.process.Process (:prev norm)))
          (is (= ["cat"] (:cmd norm)))
          (is (= {:out :string} (:opts norm))))
        (testing "cmd + prev"
          (let [parsed (p/parse-args [{:cmd ["echo" "hello"]
-                                      :prev @(process {:out :string} (format "%s %s :ls ." bb wd))}])]
+                                      :prev @(process {:out :string} (format "%s %s :ls ." bb u/wd))}])]
            (is (= ["echo" "hello"] (:cmd parsed)) (:out (:prev parsed))))))
      (is (= ["foo" "bar" "baz"] (:cmd (p/parse-args ["foo bar" "baz"]))))
      (let [norm (p/parse-args [{:out :string} "foo bar" "baz"])]
@@ -124,14 +77,14 @@
   code in a delay. Waiting for the process to end happens through realizing the
   delay. Waiting also happens implicitly by not specifying :stream, since
   realizing :out or :err needs the underlying process to finish."
-    (when-let [bb (find-bb)]
-      (let [res (process [bb wd ":out" "hello"])
+    (when-let [bb (u/find-bb)]
+      (let [res (process [bb u/wd ":out" "hello"])
             out (slurp (:out res))
             err (slurp (:err res))
             checked (check res) ;; check should return process with :exit code
             ;; populated
             exit (:exit checked)]
-        (is (= (ols "hello\n") out))
+        (is (= (u/ols "hello\n") out))
         (is (string? err))
         (is (str/blank? err))
         (is (number? exit))
@@ -142,8 +95,8 @@
   running. :in is the stdin of the process to which we can write. Calling close
   on that stream closes stdin, so a program like cat will exit. We wait for the
   process to exit by realizing the exit delay."
-    (when-let [bb (find-bb)]
-      (let [res (process [(symbol bb) (symbol wd) ':upper] {:err :inherit})
+    (when-let [bb (u/find-bb)]
+      (let [res (process [(symbol bb) (symbol u/wd) ':upper] {:err :inherit})
             _ (is (true? (.isAlive (:proc res))))
             in (:in res)
             w (io/writer in)
@@ -154,54 +107,54 @@
             _ (is (zero? exit))
             _ (is (false? (.isAlive (:proc res))))
             out-stream (:out res)]
-        (is (= (ols "HELLO\n") (slurp out-stream)))))))
+        (is (= (u/ols "HELLO\n") (slurp out-stream)))))))
 
 (deftest process-copy-input-from-string-test
-  (when-let [bb (find-bb)]
-    (let [proc (process [(symbol bb) (symbol wd) ':upper] {:in "foo"})
+  (when-let [bb (u/find-bb)]
+    (let [proc (process [(symbol bb) (symbol u/wd) ':upper] {:in "foo"})
           out (:out proc)
           ret (:exit @proc)]
       (is (= 0 ret))
-      (is (= (ols "FOO\n") (slurp out))))))
+      (is (= (u/ols "FOO\n") (slurp out))))))
 
 (deftest process-redirect-err-out-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (let [test-cmd (format "%s -cp '' %s :out :to-stdout :err :to-stderr"
-                           bb wd)]
+                           bb u/wd)]
       (testing "baseline"
         (let [res @(process {:out :string :err :string} test-cmd)]
-          (is (= (ols ":to-stdout\n") (:out res)))
-          (is (= (ols ":to-stderr\n") (:err res)))))
+          (is (= (u/ols ":to-stdout\n") (:out res)))
+          (is (= (u/ols ":to-stderr\n") (:err res)))))
       (testing "redirect"
         (let [res @(process {:out :string :err :out} test-cmd)
               out-string (:out res)
               err-null-input-stream (:err res)]
-          (is (= (ols ":to-stdout\n:to-stderr\n") out-string))
+          (is (= (u/ols ":to-stdout\n:to-stderr\n") out-string))
           (is (instance? java.io.InputStream err-null-input-stream))
           (is (= 0 (.available err-null-input-stream)))
           (is (= -1 (.read err-null-input-stream))))))))
 
 (deftest process-copy-to-out-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (let [s (with-out-str
-              @(process [(symbol bb) (symbol wd) ':upper] {:in "foo" :out *out*}))]
-      (is (= (ols "FOO\n") s)))))
+              @(process [(symbol bb) (symbol u/wd) ':upper] {:in "foo" :out *out*}))]
+      (is (= (u/ols "FOO\n") s)))))
 
 (deftest process-copy-stderr-to-out-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (let [s (with-out-str
-              (-> (process [(symbol bb) (symbol wd) ':err 'foo] {:err *out*})
+              (-> (process [(symbol bb) (symbol u/wd) ':err 'foo] {:err *out*})
                   deref :exit))]
-      (is (= (ols "foo\n") s)))))
+      (is (= (u/ols "foo\n") s)))))
 
 (deftest process-chaining-test
-  (when-let [bb (find-bb)]
-    (is (= (ols "README.md\n")
-           (-> (process [bb wd ":out" "foo" ":out" "README.md" ":out" "bar"])
-               (process [bb wd ":grep" "README.md"]) :out slurp)))
-    (is (= (ols "README.md\n")
-           (-> (sh [bb wd ":out" "foo" ":out" "README.md" ":out" "bar"])
-               (sh [bb wd ":grep" "README.md"]) :out)))))
+  (when-let [bb (u/find-bb)]
+    (is (= (u/ols "README.md\n")
+           (-> (process [bb u/wd ":out" "foo" ":out" "README.md" ":out" "bar"])
+               (process [bb u/wd ":grep" "README.md"]) :out slurp)))
+    (is (= (u/ols "README.md\n")
+           (-> (sh [bb u/wd ":out" "foo" ":out" "README.md" ":out" "bar"])
+               (sh [bb u/wd ":grep" "README.md"]) :out)))))
 
 (deftest process-dir-option-test
   ;; It is not practical to use bb for this test (bb will not be on the PATH when
@@ -223,97 +176,97 @@
                           "    System.out.println( System.getProperty (\"user.dir\"));"
                           "  }"
                           "}"]))
-    (p/shell "javac" java-src) ;; typically under 0.5s to compile
+    (p/shell {:dir test-dir} "javac" "UserDir.java") ;; typically under 0.5s to compile
     (testing "program is absolute"
-      (is (= (ols (str subdir-absolute "\n"))
+      (is (= (u/ols (str subdir-absolute "\n"))
              (-> (apply process {:dir subdir}
                         (str (fs/file java-dir "java")) args)
                  :out
                  slurp))))
     (when (fs/windows?)
       (testing "program with ext is absolute (windows)")
-      (is (= (ols (str subdir-absolute "\n"))
+      (is (= (u/ols (str subdir-absolute "\n"))
              (-> (apply process {:dir subdir}
                         (str (fs/canonicalize java)) args)
                  :out
                  slurp))))
     (testing "program is on path"
-      (is (= (ols (str subdir-absolute "\n"))
+      (is (= (u/ols (str subdir-absolute "\n"))
              (-> (apply process {:dir subdir}
                         "java" args)
                  :out
                  slurp))))
     (when (fs/windows?)
       (testing "program with ext is on path (windows)"
-        (is (= (ols (str subdir-absolute "\n"))
+        (is (= (u/ols (str subdir-absolute "\n"))
                (-> (apply process {:dir subdir}
                           (fs/file-name java) args)
                    :out
                    slurp)))))
     (testing "program is relative"
-      (is (= (ols (str java-dir "\n"))
+      (is (= (u/ols (str java-dir "\n"))
              (-> (apply process {:dir java-dir}
                         (str "./java") args)
                  :out
                  slurp))))
     (when (fs/windows?)
       (testing "program with ext is relative (windows)"
-        (is (= (ols (str java-dir "\n"))
+        (is (= (u/ols (str java-dir "\n"))
                (-> (apply process {:dir java-dir}
                           (str "./" (fs/file-name java)) args)
                    :out
                    slurp)))))
-    (fs/delete-tree test-dir)) )
+    (fs/delete-tree test-dir)))
 
 (deftest process-env-option-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (testing "request an empty env"
       ;; using -cp "" for bb here, otherwise it will expect JAVA_HOME env var to be set
-      (let [vars (-> (process [bb "-cp" "" wd ":env"] {:env {}})
+      (let [vars (-> (process [bb "-cp" "" u/wd ":env"] {:env {}})
                      :out
                      slurp
                      edn/read-string)
-            expected-vars (os always-present-env-vars)]
+            expected-vars (u/always-present-env-vars)]
         (is (= expected-vars (keys vars)))))
     (testing "add to existing env"
-      (let [out (-> (sh (format "%s %s :env" bb wd) {:extra-env {:FOO "BAR"}})
+      (let [out (-> (sh (format "%s %s :env" bb u/wd) {:extra-env {:FOO "BAR"}})
                     :out)]
         (is (str/includes? out "PATH"))
         (is (str/includes? out "\"FOO\" \"BAR\""))))
     (testing "request a specific env"
       ;; using -cp "" for bb here, otherwise it will expect JAVA_HOME env var to be set
-      (let [vars (-> (process [bb "-cp" "" wd ":env"]
+      (let [vars (-> (process [bb "-cp" "" u/wd ":env"]
                               {:env {"SOME_VAR" "SOME_VAL"
                                      :keyword_var "KWVARVAL"
                                      "keyword_val" :keyword-val}})
                      :out
                      slurp
                      edn/read-string)
-            added-vars (apply dissoc vars (os always-present-env-vars))]
+            added-vars (apply dissoc vars (u/always-present-env-vars))]
         (is (= {"SOME_VAR" "SOME_VAL"
                 "keyword_val" ":keyword-val"
                 "keyword_var" "KWVARVAL"}
                added-vars))))))
 
 (deftest process-check-throws-on-non-zero-exit-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo #"error123"
-          (-> (process (format "%s %s :err error123 :exit 1" bb wd))
+          (-> (process (format "%s %s :err error123 :exit 1" bb u/wd))
               (check)))
         "with :err string")
     (is (thrown?
           clojure.lang.ExceptionInfo #"failed"
-          (-> (process (format "%s %s :exit 1" bb wd))
+          (-> (process (format "%s %s :exit 1" bb u/wd))
               (check)))
         "With no :err string")
     (is (thrown?
           clojure.lang.ExceptionInfo #"failed"
-          (-> (process {:err *err*} (format "%s %s :exit 1" bb wd))
+          (-> (process {:err *err*} (format "%s %s :exit 1" bb u/wd))
               (check)))
         "With :err set to *err*")
     (testing "and the exception"
-      (let [command [bb wd ":exit" "1"]]
+      (let [command [bb u/wd ":exit" "1"]]
         (try
           (-> (process command)
               (check))
@@ -326,112 +279,112 @@
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (deftest process-dollar-macro-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (let [config {:a 1}]
-      (is (= (ols "{:a 1}\n") (-> ($ ~(symbol bb) ~(symbol wd) :out ~config) :out slurp)))
+      (is (= (u/ols "{:a 1}\n") (-> ($ ~(symbol bb) ~(symbol u/wd) :out ~config) :out slurp)))
       (let [sw (java.io.StringWriter.)]
-        (is (= (ols "{:a 1}\n") (do (-> ^{:out sw}
-                                        ($ ~(symbol bb) ~(symbol wd) :out ~config)
+        (is (= (u/ols "{:a 1}\n") (do (-> ^{:out sw}
+                                        ($ ~(symbol bb) ~(symbol u/wd) :out ~config)
                                         deref)
                                     (str sw)))))
       (let [sw (java.io.StringWriter.)]
-        (is (= (ols "{:a 1}\n") (do (-> ($ ~{:out sw} ~(symbol bb) ~(symbol wd) :out ~config)
+        (is (= (u/ols "{:a 1}\n") (do (-> ($ ~{:out sw} ~(symbol bb) ~(symbol u/wd) :out ~config)
                                         deref)
                                     (str sw)))))
       (let [sw (java.io.StringWriter.)]
-        (is (= (ols "{:a 1}\n") (do (-> ($ {:out sw} ~(symbol bb) ~(symbol wd) :out ~config)
+        (is (= (u/ols "{:a 1}\n") (do (-> ($ {:out sw} ~(symbol bb) ~(symbol u/wd) :out ~config)
                                         deref)
                                     (str sw))))))))
 
 (deftest process-same-as-pb-start-test
-  (when-let [bb (find-bb)]
-    (let [cmd [bb wd ":ls" "."]
+  (when-let [bb (u/find-bb)]
+    (let [cmd [bb u/wd ":ls" "."]
           out (-> (process cmd) :out slurp)]
       (is (and (string? out) (not (str/blank? out))))
       (is (str/includes? out "README.md"))
       (is (= out (-> (pb cmd) (start) :out slurp))))))
 
 (deftest process-out-to-string-test
-  (when-let [bb (find-bb)]
-    (is (= (ols "hello\n") (-> (process [bb wd ":out" "hello"] {:out :string})
-                               check
-                               :out)))))
+  (when-let [bb (u/find-bb)]
+    (is (= (u/ols "hello\n") (-> (process [bb u/wd ":out" "hello"] {:out :string})
+                                 check
+                                 :out)))))
 
 (deftest process-tokenization-test
-  (when-let [bb (find-bb)]
-    (is (= (ols "hello\n") (-> (process (format "%s %s :out hello" bb wd) {:out :string})
+  (when-let [bb (u/find-bb)]
+    (is (= (u/ols "hello\n") (-> (process (format "%s %s :out hello" bb u/wd) {:out :string})
                                check
                                :out)))
     ;; This bit of awkwardness might be avoidable.
     ;; But if we needing to test ($ "literal string") maybe not.
-    (is (= (ols "hello\n") (-> (case bb
+    (is (= (u/ols "hello\n") (-> (case bb
                                  "bb"
-                                 (case wd
+                                 (case u/wd
                                    "script/wd.clj" ^{:out :string} ($ "bb script/wd.clj :out hello")
                                    "process/script/wd.clj" ^{:out :string} ($ "bb process/script/wd.clj :out hello"))
                                  "./bb"
-                                 (case wd
+                                 (case u/wd
                                    "script/wd.clj" ^{:out :string} ($ "./bb script/wd.clj :out hello")
-                                   "process/script/wd.clj" ^{:out :string} ($ "./bb process/script/wd.clj :out hello") ))
+                                   "process/script/wd.clj" ^{:out :string} ($ "./bb process/script/wd.clj :out hello")))
                                check
                                :out)))
-    (is (= (ols "hello\n") (-> (sh (format "%s %s :out hello" bb wd))
+    (is (= (u/ols "hello\n") (-> (sh (format "%s %s :out hello" bb u/wd))
                                :out)))))
 
 (deftest process-space-in-cmd-test
-  (when-let [bb (find-bb)]
-    (let [proc @(p/process [(str bb " ") wd ":out" "hello"] {:out :string})]
-      (is (= (ols "hello\n") (:out proc)))
+  (when-let [bb (u/find-bb)]
+    (let [proc @(p/process [(str bb " ") u/wd ":out" "hello"] {:out :string})]
+      (is (= (u/ols "hello\n") (:out proc)))
       (is (zero? (:exit proc))))))
 
 #?(:bb nil ;; skip longer running test when running form babashka proper
    :clj
    (deftest process-deref-timeout-test
-     (when-let [bb (find-bb)]
-       (is (= ::timeout (deref (process [bb wd ":sleep" "500"]) 250 ::timeout)))
-       (is (= 0 (:exit (deref (process [bb wd]) 250 nil)))))))
+     (when-let [bb (u/find-bb)]
+       (is (= ::timeout (deref (process [bb u/wd ":sleep" "500"]) 250 ::timeout)))
+       (is (= 0 (:exit (deref (process [bb u/wd]) 250 nil)))))))
 
 (deftest shell-test
-  (when-let [bb (find-bb)]
-    (is (str/includes? (:out (p/shell {:out :string} (format "%s %s :out hello" bb wd))) "hello"))
-    (is (str/includes? (-> (p/shell {:out :string} (format "%s %s :out hello" bb wd))
-                           (p/shell {:out :string } (format "%s %s :upper" bb wd))
+  (when-let [bb (u/find-bb)]
+    (is (str/includes? (:out (p/shell {:out :string} (format "%s %s :out hello" bb u/wd))) "hello"))
+    (is (str/includes? (-> (p/shell {:out :string} (format "%s %s :out hello" bb u/wd))
+                           (p/shell {:out :string } (format "%s %s :upper" bb u/wd))
                            :out)
                        "HELLO"))
-    (is (= 1 (do (p/shell {:continue true} (format "%s %s :exit 1" bb wd)) 1)))))
+    (is (= 1 (do (p/shell {:continue true} (format "%s %s :exit 1" bb u/wd)) 1)))))
 
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (deftest dollar-pipe-test
-  (when-let [bb (find-bb)]
-    (is (= (ols "HELLO\n")
-           (-> ($ ~(symbol bb) ~(symbol wd) :out hello)
-               ($ {:out :string} ~(symbol bb) ~(symbol wd) :upper) deref :out)))
-    (is (= (ols "HELLO\n")
-           (-> ($ ~(symbol bb) ~(symbol wd) :out hello)
-               ^{:out :string} ($ ~(symbol bb) (symbol wd) :upper) deref :out)))
-    (is (= (ols "hello\n")
-           (-> ($ ~(symbol bb) ~(symbol wd) :out goodbye :out hello)
-               ($ ~(symbol bb) ~(symbol wd) :grep hello) deref :out slurp)))))
+  (when-let [bb (u/find-bb)]
+    (is (= (u/ols "HELLO\n")
+           (-> ($ ~(symbol bb) ~(symbol u/wd) :out hello)
+               ($ {:out :string} ~(symbol bb) ~(symbol u/wd) :upper) deref :out)))
+    (is (= (u/ols "HELLO\n")
+           (-> ($ ~(symbol bb) ~(symbol u/wd) :out hello)
+               ^{:out :string} ($ ~(symbol bb) (symbol u/wd) :upper) deref :out)))
+    (is (= (u/ols "hello\n")
+           (-> ($ ~(symbol bb) ~(symbol u/wd) :out goodbye :out hello)
+               ($ ~(symbol bb) ~(symbol u/wd) :grep hello) deref :out slurp)))))
 
 (deftest redirect-file-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (fs/with-temp-dir [tmp {}]
       (let [out (fs/file tmp "out.txt")]
-        @(p/process (format "%s %s :out hello" bb wd)
+        @(p/process (format "%s %s :out hello" bb u/wd)
                     {:out :write :out-file out})
-        (is (= (ols "hello\n") (slurp out)))
-        @(p/process (format "%s %s :out goodbye" bb wd)
+        (is (= (u/ols "hello\n") (slurp out)))
+        @(p/process (format "%s %s :out goodbye" bb u/wd)
                     {:out :append :out-file out})
-        (is (= (ols "hello\ngoodbye\n") (slurp out)))))
+        (is (= (u/ols "hello\ngoodbye\n") (slurp out)))))
     (fs/with-temp-dir [tmp {}]
       (let [out (fs/file tmp "err.txt")]
-        @(p/process (format "%s %s :err 'err,hello'" bb wd)
+        @(p/process (format "%s %s :err 'err,hello'" bb u/wd)
                     {:err :write :err-file out})
-        (is (= (ols "err,hello\n") (slurp out)))
-        @(p/process (format "%s %s :err 'grrr-oodbye'" bb wd)
+        (is (= (u/ols "err,hello\n") (slurp out)))
+        @(p/process (format "%s %s :err 'grrr-oodbye'" bb u/wd)
                     {:err :append :err-file out})
-        (is (= (ols "err,hello\ngrrr-oodbye\n") (slurp out)))))))
+        (is (= (u/ols "err,hello\ngrrr-oodbye\n") (slurp out)))))))
 
 (deftest pprint-test
   ;; #?(:bb nil ;; in bb we already required the babashka.process.pprint namespace
@@ -439,23 +392,23 @@
   ;;    (testing "calling pprint on a process without requiring pprint namespace causes exception (ambiguous on pprint/simple-dispatch multimethod)"
   ;;      (is (thrown-with-msg? IllegalArgumentException #"Multiple methods in multimethod 'simple-dispatch' match dispatch value"
   ;;                            (-> (process "cat missing-file.txt") pprint)))))
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (testing "after requiring pprint namespace, process gets pprinted as a map"
       (do
         (require '[babashka.process] :reload '[babashka.process.pprint] :reload)
-        (is (str/includes? (with-out-str (-> (process (format "%s %s :out hello" bb wd)) pprint)) ":proc"))))))
+        (is (str/includes? (with-out-str (-> (process (format "%s %s :out hello" bb u/wd)) pprint)) ":proc"))))))
 
 (deftest pre-start-fn-test
-  (when-let [bb (find-bb)]
+  (when-let [bb (u/find-bb)]
     (testing "a print fn option gets executed just before process is started"
       (let [p {:pre-start-fn #(apply println "Running" (:cmd %))}
             resolved-bb (resolve-exe bb)]
-        (is (= (ols (format "Running %s %s :out hello1\n" resolved-bb wd))
-               (with-out-str (process (format "%s %s :out hello1" bb wd) p))))
-        (is (= (ols (format "Running %s %s :out hello2\n" resolved-bb wd))
-               (with-out-str (-> (pb [bb wd ":out" "hello2"] p) start))))
-        (is (= (ols (format "Running %s %s :exit 32\n" resolved-bb wd))
-               (with-out-str (sh (format "%s %s :exit 32" bb wd) p))))))))
+        (is (= (u/ols (format "Running %s %s :out hello1\n" resolved-bb u/wd))
+               (with-out-str (process (format "%s %s :out hello1" bb u/wd) p))))
+        (is (= (u/ols (format "Running %s %s :out hello2\n" resolved-bb u/wd))
+               (with-out-str (-> (pb [bb u/wd ":out" "hello2"] p) start))))
+        (is (= (u/ols (format "Running %s %s :exit 32\n" resolved-bb u/wd))
+               (with-out-str (sh (format "%s %s :exit 32" bb u/wd) p))))))))
 
 (defmacro ^:private jdk9+ []
   (if (identical? ::pre-jdk9
@@ -464,73 +417,73 @@
     '(do
        (require '[babashka.process :refer [pipeline]])
        (deftest pipeline-prejdk9-test
-         (when-let [bb (find-bb)]
+         (when-let [bb (u/find-bb)]
            (testing "pipeline returns processes nested with ->"
              (let [resolved-bb (resolve-exe bb)]
-               (is (= [[resolved-bb wd ":out" "foo"]
-                       [resolved-bb wd ":upper"]]
-                      (map :cmd (pipeline (-> (process [bb wd ":out" "foo"])
-                                              (process [bb wd ":upper"])))))))))))
+               (is (= [[resolved-bb u/wd ":out" "foo"]
+                       [resolved-bb u/wd ":upper"]]
+                      (map :cmd (pipeline (-> (process [bb u/wd ":out" "foo"])
+                                              (process [bb u/wd ":upper"])))))))))))
     '(do
        (require '[babashka.process :refer [pipeline pb]])
        (deftest inherit-test
-         (when-let [bb (find-bb)]
-           (let [proc (process (format "%s %s :out ''" bb wd) {:shutdown p/destroy-tree
+         (when-let [bb (u/find-bb)]
+           (let [proc (process (format "%s %s :out ''" bb u/wd) {:shutdown p/destroy-tree
                                                                :inherit true})
                  null-input-stream-class (class (:out proc))
                  null-output-stream-class (class (:in proc))]
              (is (= null-input-stream-class (class (:err proc))))
-             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+             (let [x (process [bb u/wd ":upper"] {:shutdown p/destroy-tree
                                                 :inherit true
                                                 :in "foo"})]
                (is (not= null-output-stream-class (class (:in x))))
                (is (= null-input-stream-class (class (:out x))))
                (is (= null-input-stream-class (class (:err x)))))
-             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+             (let [x (process [bb u/wd ":upper"] {:shutdown p/destroy-tree
                                                 :inherit true
                                                 :out :string})]
                (is (= null-output-stream-class (class (:in x))))
                (is (not= null-input-stream-class (class (:out x))))
                (is (= null-input-stream-class (class (:err x)))))
-             (let [x (process [bb wd ":upper"] {:shutdown p/destroy-tree
+             (let [x (process [bb u/wd ":upper"] {:shutdown p/destroy-tree
                                                 :inherit true
                                                 :err :string})]
                (is (= null-output-stream-class (class (:in x))))
                (is (= null-input-stream-class (class (:out x))))
                (is (not= null-input-stream-class (class (:err x))))))))
        (deftest pipeline-test
-         (when-let [bb (find-bb)]
+         (when-let [bb (u/find-bb)]
            (testing "pipeline returns processes nested with ->"
              (let [resolved-bb (resolve-exe bb)]
-               (is (= [[resolved-bb wd ":out" "foo"]
-                       [resolved-bb wd ":upper"]]
-                      (map :cmd (pipeline (-> (process [bb wd ":out" "foo"])
-                                              (process [bb wd ":upper"]))))))))
+               (is (= [[resolved-bb u/wd ":out" "foo"]
+                       [resolved-bb u/wd ":upper"]]
+                      (map :cmd (pipeline (-> (process [bb u/wd ":out" "foo"])
+                                              (process [bb u/wd ":upper"]))))))))
            (testing "pipeline returns processes created with pb"
              (let [resolved-bb (resolve-exe bb)]
-               (is (= [[resolved-bb wd ":out" "foo"]
-                       [resolved-bb wd ":upper"]]
-                      (map :cmd (pipeline (pb [bb wd ":out" "foo"])
-                                          (pb [bb wd ":upper"])))))))
+               (is (= [[resolved-bb u/wd ":out" "foo"]
+                       [resolved-bb u/wd ":upper"]]
+                      (map :cmd (pipeline (pb [bb u/wd ":out" "foo"])
+                                          (pb [bb u/wd ":upper"])))))))
            (testing "pbs can be chained with ->"
-             (let [chain (-> (pb [bb wd ":out" "hello"])
-                             (pb [bb wd ":upper"] {:out :string}) start deref)
+             (let [chain (-> (pb [bb u/wd ":out" "hello"])
+                             (pb [bb u/wd ":upper"] {:out :string}) start deref)
                    resolved-bb (resolve-exe bb)]
-               (is (= (ols "HELLO\n") (slurp (:out chain))))
-               (is (= [[resolved-bb wd ":out" "hello"]
-                       [resolved-bb wd ":upper"]] (map :cmd (pipeline chain))))))))
+               (is (= (u/ols "HELLO\n") (slurp (:out chain))))
+               (is (= [[resolved-bb u/wd ":out" "hello"]
+                       [resolved-bb u/wd ":upper"]] (map :cmd (pipeline chain))))))))
        (deftest exit-fn-test
-         (when-let [bb (find-bb)]
+         (when-let [bb (u/find-bb)]
            (let [exit-code (promise)]
-             (process [bb wd ":exit" "42"]
+             (process [bb u/wd ":exit" "42"]
                       {:exit-fn (fn [proc] (deliver exit-code (:exit proc)))})
              (is (= 42 @exit-code))))))))
 
 (jdk9+)
 
 (deftest alive-lives-test
-  (when-let [bb (find-bb)]
-    (let [{:keys [in] :as res} (process [(symbol bb) (symbol wd) ':upper])]
+  (when-let [bb (u/find-bb)]
+    (let [{:keys [in] :as res} (process [(symbol bb) (symbol u/wd) ':upper])]
       (is (true? (p/alive? res)))
       (.close in)
       @res


### PR DESCRIPTION
New bb tasks:
- clean - delete build work
- test:bb - runs all tests under babashka
- test:native - runs exec tests against native image of run_exec.clj
- test:jvm - (renamed from test) runs non-exec tests under jvm clojure

CI:
- GitHub Actions updated to run native image tests
  - jobs renamed to match CircleCI naming convention
- CircleCI was doing a subset of GitHub Actions work, it now is a full reflection.
  - added jdk install support in script/circle_ci.clj
  - bootstrapping CI to be able to run bb and then scripting in bb is much more pleasant/maintainable than scripting in bash+Powershell
  - used jdk install support even on linux, instead of trying to to select jdk via docker image. This made config cleaner, allowed for consitent jdk selection across OSes and had surprisingly little performance hit especially after caching jdks.
  - installing jdks via bb hugely more performant than doing so via brew/scoop/chocolatey
  - jdk download urls, and shas discovered by disco API. See: https://github.com/foojayio/discoapi
- Both CIs are temporarily using a SHAPSHOT release of bb for `babashka.process/exec` reload support. We'll turf this after next release of babashka.

Add `run_exec.clj` - a wee program to exercise `exec`
- source and build support under ./test-native
- includes script-adjacent `bb.edn` to suport running as a script and reloading sources instead of using babashka built-in babashka.process
- specify `babashka.process.test.reload` system property to signal that `run_exec.clj` should reload `babashka.process` from sources when running from bb.
- note: `test:native` task does not natively compile tests, it only natively compiles `run_exec.clj`. It launches natively compiled `run_exec.clj` via jvm clojure and observes results for correctness.

Test utilities moved to `babashka.process.test-utils` so that they can be used by existing `babashka.process-test` and new:
- `babashka.process-exec-test`
- bb build scripts (specifically: test-native/bb.edn)

Add :ps-me to wee dummy wd.clj to support `exec` arg0 testing for macOS and Linux.

Add doc/dev.md with some relevant notes/pointers.

Other changes:
- deleted `script/test` bash script, it is replaced by bb tasks
- we now look for bb first in current dir, then on path. This seems the safer way to choose bb when running babashka.process tests from babashka
- tests now printing bb version to give confidence we are using the bb we want to be using

Bugs found and fixed as a result of testing:
- tests using java now understand that java executable path can contain spaces.
- test using `javac` seem to be happier running `javac` from same dir as source
- `exec` now converting `:env` and `:extra-env` keywords the same way `process` function do, see #123

Closes #117, Fixes #123