### PR TITLE
Ensure `exec` supports `:cmd` opt

### DIFF
--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -582,7 +582,7 @@
 
   Supported `opts`
   - `:arg0`: override first argument (the executable). No-op on Windows.
-  - `:env`,`:extra-env`,`:escape`,`:pre-start-fn` : see `process`."
+  - `:cmd`, `:env`,`:extra-env`, `:escape`,`:pre-start-fn` : see `process`."
   {:arglists '([opts? & args])}
   [& args]
   (let [{:keys [cmd opts]} (parse-args args)]

--- a/test/babashka/process_exec_test.clj
+++ b/test/babashka/process_exec_test.clj
@@ -183,3 +183,11 @@
       (let [java-dir (-> (fs/which "java") fs/parent fs/absolutize str)]
         (shell/with-sh-dir java-dir
           (= expected (run-exec "./java -version")))))))
+
+(deftest cmd-opt-test
+  (when-let [bb (u/find-bb)]
+    (is (= {:exit 0
+            :out (u/ols "o-one\no-two\n")
+            :err (u/ols "e-one\n")}
+           (run-exec {:cmd [bb u/wd ":out" "o-one" ":err" "e-one" ":out" "o-two"]
+                      :out :string :err :string})))))


### PR DESCRIPTION
I think this was fixed by 3f093b70e114ff8dc318f21dec01a7a2a2fe4fcc.

Added test and updated docstring.

Closes #125