### PR TITLE
test: bump Graalvm to JDK 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     working_directory: ~/repo
   windows:
     machine:
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2022-gui:current
       resource_class: windows.medium
       shell: powershell.exe -ExecutionPolicy Bypass
     working_directory: ~/repo
@@ -199,7 +199,7 @@ workflows:
               os: [linux, macos, windows]
               jdk: ['temurin@8','temurin@11','temurin@17']
       - test-native:
-          name: test-<< matrix.os >>-native
+          name: test-<< matrix.os >>-<< matrix.jdk>>
           matrix:
             parameters:
               os: [linux, macos, windows]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ workflows:
           matrix:
             parameters:
               os: [linux, macos, windows]
-              jdk: ['graalvm_ce19']
+              jdk: ['graalvm@21', 'graalvm_community@21']
       - deploy:
           filters:
             branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macOS, windows]
+        distribution: [graalvm, graalvm-community]
 
     runs-on: ${{ matrix.os }}-latest
-    name: test-${{ matrix.os }}-native
+    name: test-${{ matrix.os }}-${{ matrix.distribution}}-native
 
     steps:
     - name: "Checkout code"
@@ -66,10 +67,9 @@ jobs:
     - name: Install GraalVM
       uses: graalvm/setup-graalvm@v1
       with:
-        # match version babashka uses
-        version: '22.3.1'
-        java-version: 19
-        components: 'native-image'
+        # match version babashka uses (or will soon use)
+        java-version: '21'
+        distribution: ${{ matrix.distribution }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: "Restore Cache"

--- a/script/circle_ci.clj
+++ b/script/circle_ci.clj
@@ -128,11 +128,15 @@
     (set-jdk-env os install-dir)))
 
 (comment
+
   (install-jdk "macos" "temurin@11")
   (install-jdk "windows" "temurin@17")
   (install-jdk "linux" "temurin@11")
   (install-jdk "linux" "graalvm_ce19")
   (install-jdk "windows" "graalvm_ce19")
+
+  (install-jdk "linux" "graalvm@21" )
+  (install-jdk "linux" "graalvm_community@21" )
 
   (install-jdk "linux" "temurin@8")
 

--- a/test/babashka/process_exec_test.clj
+++ b/test/babashka/process_exec_test.clj
@@ -174,7 +174,7 @@
   (let [expected (shell/sh "java" "-version")]
     (is (zero? (:exit expected)) "sanity expected exit")
     (is (str/blank? (:out expected)) "sanity expected out" )
-    (is (re-find #"(?i)jdk" (:err expected)) "sanity expected err")
+    (is (re-find #"(?i)(jdk|java)" (:err expected)) "sanity expected err")
     (testing "on-path"
       (is (= expected (run-exec "java -version"))))
     (testing "absolute"


### PR DESCRIPTION
Setup CIs to run native tests against both Oracle and Community variants.

Closes #144