### PR TITLE
circleci: fix jdk download

### DIFF
--- a/script/circle_ci.clj
+++ b/script/circle_ci.clj
@@ -18,7 +18,7 @@
                                {:query-params {"distro" distro
                                                "package_type" "jdk"
                                                "latest" "available"
-                                               "jdk_version" jdk-major
+                                               "version" jdk-major
                                                "operating_system" os
                                                "architecture" "x64"
                                                "archive_type" archive-type}})


### PR DESCRIPTION
We use the disco API to discover JDKs on CircleCI. Using `version` instead of `jdk_version` seems to fix things.