### PR TITLE
ci: drop testing of jdk8 on macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
       - run:
           name: "Setup JDK"
           command: |
-            bb -ci-install-jdk <<parameters.os>> << parameters.jdk >>
+            bb -ci-install-jdk << parameters.jdk >>
 
 jobs:
   test:
@@ -198,6 +198,9 @@ workflows:
             parameters:
               os: [linux, macos, windows]
               jdk: ['temurin@8','temurin@11','temurin@17']
+            exclude:
+              - os: macos
+                jdk: 'temurin@8'
       - test-native:
           name: test-<< matrix.os >>-<< matrix.jdk>>
           matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         java-version: ["8", "11", "17"]
         os: [ubuntu, macOS, windows]
+        exclude:
+          - java-version: "8"
+            os: macOS
 
     runs-on: ${{ matrix.os }}-latest
     name: test-${{ matrix.os }}-temurin@${{ matrix.java-version }}


### PR DESCRIPTION
**circleci: configuring for Apple silicon**

I could not find a combination of an m1 `resource_class` and `xcode` that did not produce a "not available for your project" error from CircleCI. So I left out `resource_class` for now. Perhaps all will be good after Apple Silicon is the only supportted macos executor on June 29, 2024. I'll come back and check on this an open a new issue if necessary.

**circleci: jdk: infer os and architecture from host**

JDK architecture was hardcoded to x64 but this is not appropriate for our new Apple silicone hardware. We now infer architecture from host.

Figured might as well infer os from host as well.

Adjusted install dir name to include os and architecture to support testability and a potential future where one might, for example, install x64 on Apple Silicon hardware and use Rosetta. The latter would require a tweak to allow architecture to be selected by the user. We'll allow for that in the future should we need it.

Closes #153