### PR TITLE
ci: test against clojure 1.12, bump 1.11 current

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,4 +4,5 @@
                   :main-opts ["-m" "cognitect.test-runner"]}
            :clj-1.9 {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
            :clj-1.10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
-           :clj-1.11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}}}
+           :clj-1.11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
+           :clj-1.12 {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}}}}}


### PR DESCRIPTION
Clojure 1.12 is automatically picked up by `bb test:jvm :clj-all` which is what we use on CI.

Closes #159