### PR TITLE
docs: minor: update descriptions of `:continue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This is particularly handy when you want to supply commands coming from the comm
 (apply shell "ls -la" *command-line-args*)
 ```
 
-The `shell` function checks the exit code and throws if it is non-zero:
+The `shell` function checks the command's exit code and throws if it is non-zero:
 
 ``` clojure
 user=> (shell "ls nothing")
@@ -96,8 +96,8 @@ ls: nothing: No such file or directory
 Execution error (ExceptionInfo) at babashka.process/check (process.cljc:113).
 ```
 
-To avoid throwing, you can use `:continue true`. You will still see the error
-being printed to stderr, but no exception will be thrown. That is convenient
+To avoid throwing when the command's exit code is non-zero, use `:continue true`. 
+You will still see the error printed to stderr, but no exception will be thrown. This is convenient
 when you want to handle the `:exit` code yourself:
 
 ``` clojure
@@ -105,6 +105,9 @@ user=> (-> (shell {:continue true} "ls nothing") :exit)
 ls: nothing: No such file or directory
 1
 ```
+
+> Note that `:continue true` only suppresses throwing an exception when the executed command's exit code is non-zero.
+> Other exceptions can throw, for example, when the executable is not found.
 
 To collect output as a `:string`, use the `:out :string` option as the first argument:
 

--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -638,13 +638,17 @@
 (defn shell
   "Convenience function around `process` that was originally in `babashka.tasks`.
   Defaults to inheriting I/O: input is read and output is printed
-  while the process runs. Throws on non-zero exit codes. Kills all
+  while the process runs. Defaults to throwing on non-zero exit codes. Kills all
   subprocesses on shutdown. Optional options map can be passed as the
   first argument, followed by multiple command line arguments. The
   first command line argument is automatically tokenized. Counter to
   what the name of this function may suggest, it does not start a
   new (bash, etc.) shell, it just shells out to a program. As such, it
   does not support bash syntax like `ls *.clj`.
+
+  Supported options:
+  - `:continue`: if `true`, suppresses throwing on non-zero process exit code.
+  - see `process` for other options
 
   Examples:
 


### PR DESCRIPTION
As discussed on Slack: https://clojurians.slack.com/archives/CLX41ASCS/p1718798012312359?thread_ts=1718774256.150799&cid=CLX41ASCS

**me**
> @borkdude, I reviewed the babashka/process docs on this, and they are pretty good, but I guess they could be reworded slightly to be clearer.
Also, I noticed :continue is described in README but not in any docstring. Would you like a small PR?

**you**
> yes please!