### PR TITLE
Fix: the shutdown hook should be removed when the process ends to avoid a memory leak.

### DIFF
--- a/src/babashka/process.cljc
+++ b/src/babashka/process.cljc
@@ -422,7 +422,11 @@
                (.thenRun (fn []
                            ;; To avoid a memory leak remove the hook when the process ends:
                            (-> (Runtime/getRuntime)
-                               (.removeShutdownHook hook))))))))
+                               (.removeShutdownHook hook))
+                           ;; But run the shutdown hook to ensure that cleanup
+                           ;; tasks are executed:
+                           (.start hook)
+                           ))))))
       (when exit-fn
         (if-before-jdk8
          (throw (ex-info "The `:exit-fn` option is not support on JDK 8 and lower." res))
@@ -479,7 +483,8 @@
       - `:cmd` - a vector of the tokens of the command to be executed (e.g. `[\"ls\" \"foo\"]`)
    - `:shutdown`: shutdown hook, defaults to `nil`. Takes process
       map. Typically used with `destroy` or `destroy-tree` to ensure long
-      running processes are cleaned up on shutdown.
+      running processes are cleaned up on shutdown. The shutdown hook is
+      executed as soon as the child process ends.
    - `:exit-fn`: a function which is executed upon exit. Receives process map as argument. Only supported in JDK11+."
   {:arglists '([opts? & args])}
   [& args]


### PR DESCRIPTION
Thanks a lot for creating babashka/process , it is awesome and helps us a lot :partying_face: 

We found this edge case due to an OutOfMemory issue on one of our production servers. It only occurs after several days. We call process/shell three times per second. Below a suggestion for a potential fix.